### PR TITLE
🚨 Fix: websocket.ts - VITE_API_URL을 ws로 변경하는 로직 제거

### DIFF
--- a/src/apis/websocket.ts
+++ b/src/apis/websocket.ts
@@ -143,7 +143,7 @@ export class WebSocketService {
   }
 
   private async initializeClient(token: string): Promise<void> {
-    const WS_URL = import.meta.env.VITE_API_URL.replace(/^http/, 'ws') + '/ws';
+    const WS_URL = import.meta.env.VITE_API_URL + '/ws';
 
     this.client = new Client({
       webSocketFactory: () => new SockJS(WS_URL),
@@ -178,12 +178,12 @@ export class WebSocketService {
     window.dispatchEvent(new CustomEvent('websocketDisconnected'));
   }
 
-  private handleStompError(frame: any): void {
+  private handleStompError(frame: unknown): void {
     console.error('Stomp 에러:', frame);
     this.handleConnectionError();
   }
 
-  private handleWebSocketError(event: Event): void {
+  private handleWebSocketError(): void {
     // console.error('웹소켓 에러:', event);
     this.handleConnectionError();
   }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`hotfix/websocket-url-fix` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
SockJS WebSocket 연결 오류 해결
기존에  Native WebSocket 방식으로 구현했던 코드를 SockJS으로 수정했습니다.
(SockJS는 HTTP/HTTPS URL만 지원 -> 문제 코드는 `http://`를 `ws://`로 변경하려고 해서 오류가 발생)

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `src/apis/websocket.ts`의 `initializeClient` 메서드에서 URL 변환 로직 제거
- [x] SockJS가 지원하는 HTTP/HTTPS URL을 그대로 사용하도록 수정
- [x] 린터 에러 수정 (`any` 타입을 `unknown`으로 변경, 사용하지 않는 매개변수 제거)

## 🔧 코드 변경 내용
```typescript
// 변경 전
const WS_URL = import.meta.env.VITE_API_URL.replace(/^http/, 'ws') + '/ws';

// 변경 후  
const WS_URL = import.meta.env.VITE_API_URL + '/ws';
```

## 🗂️ 해결된 문제
- **오류**: `SyntaxError: The URL's scheme must be either 'http:' or 'https:'. 'wss:' is not allowed.`
- **원인**: SockJS는 HTTP/HTTPS URL만 지원하는데 WebSocket URL(`ws://`, `wss://`)을 사용하려고 했음
- **해결**: SockJS의 동작 방식에 맞게 HTTP/HTTPS URL을 그대로 사용


## 🧪 테스트 체크리스트
- [ ] 로그인 후 웹소켓 연결 성공
- [ ] 브라우저 콘솔에서 WebSocket 관련 오류 없음 (웹소켓 연결 성공)