### PR TITLE
[Feat/Book-38] ✨ Feature: 책장, 도서 페이지 접속 gtag / 도서 리뷰 발행 추적 태그 추가

### DIFF
--- a/src/pages/book-editor/BookEditorPage.tsx
+++ b/src/pages/book-editor/BookEditorPage.tsx
@@ -6,8 +6,10 @@ import BookReviewDisplay from '@pages/book-viewer/components/BookReviewDisplay';
 import { BOOK_THEME } from '@/constants/bookTheme';
 import ThemeSelector from './components/ThemeSelector';
 import { useToastStore } from '@/store/useToastStore';
+import { useUserStore } from '@/store/useUserStore';
 import { bookAPI } from '@/apis/book';
 import { BookReviewData } from '@/types/book';
+import { useBackofficeFeatureTracking } from '@/hooks/useBackofficeBatchTracking';
 
 interface BookEditorPageProps {
   bookTitle: string;
@@ -29,9 +31,16 @@ const BookEditorPage = ({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const showToast = useToastStore((state) => state.showToast);
+  const { user } = useUserStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isEditMode, setIsEditMode] = useState(
     searchParams.get('mode') === 'edit',
+  );
+
+  const { startTracking, endTracking } = useBackofficeFeatureTracking(
+    'book',
+    user?.userId?.toString(),
+    1000,
   );
   const [reviewFields, setReviewFields] = useState<BookReviewData>(() => {
     // localStorage에서 임시저장 데이터 불러오기
@@ -79,6 +88,11 @@ const BookEditorPage = ({
     const timer = setInterval(autoSave, 5000);
     return () => clearInterval(timer);
   }, [autoSave]);
+
+  // 컴포넌트 마운트 시 추적 시작
+  useEffect(() => {
+    startTracking();
+  }, [startTracking]);
 
   // 수정 모드일 때 기존 서평 데이터 불러오기
   useEffect(() => {
@@ -170,10 +184,16 @@ const BookEditorPage = ({
 
       // 공통 처리 로직
       localStorage.removeItem(`draft-review-${bookId}`);
+
+      endTracking();
+
       navigate(`/book/${bookId}`, { replace: true });
     } catch (error) {
       console.error('서평 저장 중 오류 발생:', error);
       showToast('서평 저장에 실패했습니다 ꌩ-ꌩ', 'error');
+
+      // 실패 시에도 추적 종료
+      endTracking();
     } finally {
       setIsSubmitting(false);
     }

--- a/src/pages/book-editor/BookEditorPage.tsx
+++ b/src/pages/book-editor/BookEditorPage.tsx
@@ -9,7 +9,10 @@ import { useToastStore } from '@/store/useToastStore';
 import { useUserStore } from '@/store/useUserStore';
 import { bookAPI } from '@/apis/book';
 import { BookReviewData } from '@/types/book';
-import { useBackofficeFeatureTracking } from '@/hooks/useBackofficeBatchTracking';
+import {
+  useAutoBackofficeTracking,
+  useBackofficeFeatureTracking,
+} from '@/hooks/useBackofficeBatchTracking';
 
 interface BookEditorPageProps {
   bookTitle: string;
@@ -36,6 +39,9 @@ const BookEditorPage = ({
   const [isEditMode, setIsEditMode] = useState(
     searchParams.get('mode') === 'edit',
   );
+
+  // 페이지 접속 추적 (자동 시작/종료)
+  useAutoBackofficeTracking('book', user?.userId?.toString(), 1000);
 
   const { startTracking, endTracking } = useBackofficeFeatureTracking(
     'book',

--- a/src/pages/bookcase/BookCasePage.tsx
+++ b/src/pages/bookcase/BookCasePage.tsx
@@ -11,6 +11,7 @@ import Loading from '@components/Loading';
 import AnimationGuide from '@components/AnimationGuide';
 import { useToastStore } from '@/store/useToastStore';
 import { useUserStore } from '@/store/useUserStore';
+import { useBackofficeFeatureTracking } from '@/hooks/useBackofficeBatchTracking';
 
 const BookCasePage = () => {
   const { showToast } = useToastStore();
@@ -22,6 +23,12 @@ const BookCasePage = () => {
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isGuideOpen, setIsGuideOpen] = useState(true);
+
+  // 도서 추가 추적 - 통일된 'book' featureName 사용
+  const {
+    startTracking: startBookAddTracking,
+    endTracking: endBookAddTracking,
+  } = useBackofficeFeatureTracking('book', user?.userId?.toString(), 1000);
 
   const BOOKS_PER_ROW = 15;
   const [isDragging, setIsDragging] = useState(false);
@@ -220,7 +227,10 @@ const BookCasePage = () => {
       </div>
 
       <ToolBoxButton
-        onAddBook={() => setIsModalOpen(true)}
+        onAddBook={() => {
+          startBookAddTracking();
+          setIsModalOpen(true);
+        }}
         onOpenList={() => setIsListOpen(true)}
         isOtherUserBookcase={user?.userId !== Number(userId)}
       />
@@ -260,6 +270,8 @@ const BookCasePage = () => {
               ]);
               setTotalCount((prev) => prev + 1);
               setIsModalOpen(false);
+
+              endBookAddTracking();
             } catch (error) {
               console.error('책 추가에 실패했습니다:', error);
               setBooks((prevBooks) =>
@@ -270,6 +282,8 @@ const BookCasePage = () => {
               );
               setTotalCount((prev) => prev - 1);
               showToast('책 추가에 실패했습니다 ꌩ-ꌩ', 'error');
+
+              endBookAddTracking();
             }
           }}
         />

--- a/src/pages/bookcase/BookCasePage.tsx
+++ b/src/pages/bookcase/BookCasePage.tsx
@@ -11,7 +11,10 @@ import Loading from '@components/Loading';
 import AnimationGuide from '@components/AnimationGuide';
 import { useToastStore } from '@/store/useToastStore';
 import { useUserStore } from '@/store/useUserStore';
-import { useBackofficeFeatureTracking } from '@/hooks/useBackofficeBatchTracking';
+import {
+  useAutoBackofficeTracking,
+  useBackofficeFeatureTracking,
+} from '@/hooks/useBackofficeBatchTracking';
 
 const BookCasePage = () => {
   const { showToast } = useToastStore();
@@ -23,6 +26,9 @@ const BookCasePage = () => {
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isGuideOpen, setIsGuideOpen] = useState(true);
+
+  // 페이지 접속 추적 (자동 시작/종료)
+  useAutoBackofficeTracking('book', user?.userId?.toString(), 1000);
 
   // 도서 추가 추적 - 통일된 'book' featureName 사용
   const {


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Feat/Book-38` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
도서 관련 이벤트 추적을 위한 백오피스 배치 추적 시스템을 구현했습니다.
책장 페이지에서 도서 추가와 도서 리뷰 작성/수정 시 사용자 행동을 추적하여 분석할 수 있도록 했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `useBackofficeBatchTracking.ts` 훅을 활용한 도서 이벤트 추적 구현
- [x] `BookCasePage.tsx`에 도서 추가 추적 기능 추가
- [x] `BookEditorPage.tsx`에 도서 리뷰 작성/수정 추적 기능 추가
- [x] 페이지 접속 시 자동 추적 기능 구현
- [x] 통일된 `book` featureName으로 모든 도서 관련 이벤트 추적
- [x] 사용자 ID 포함하여 개인화된 추적 데이터 수집
- [x] 최소 1초 이상 사용 시에만 추적하여 정확한 사용 패턴 분석

## 🔧 기술적 구현 사항
### 추적 이벤트 종류
1. 페이지 접속 추적: `useAutoBackofficeTracking` 사용
   - 책장 페이지 (`/bookcase/:userId`) 접속 시
   - 도서 리뷰 편집 페이지 (`/book/:bookId?mode=edit`) 접속 시

2. 사용자 액션 추적: `useBackofficeFeatureTracking` 사용
   - 도서 추가 버튼 클릭 → 도서 추가 완료/실패
   - 리뷰 작성 시작 → 리뷰 저장 완료/실패

### 추적 데이터 구조
```typescript
{
  featureName: 'book',           // 통일된 도서 관련 이벤트
  userId: string,                // 사용자 식별
  startTime: number,             // 추적 시작 시간
  endTime: number,               // 추적 종료 시간
  duration: number               // 사용 시간 (밀리초)
}
```

## 📢 이슈 정보
#38 - 도서 리뷰 발행 추적 태그 추가 