### PR TITLE
[Fix/Header-42] 🚨 Fix: 헤더 숨김 메뉴 바깥 영역 클릭에 닫힘 기능 추가

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -25,12 +25,11 @@ const Header = () => {
   const housemateButtonRef = useRef<HTMLButtonElement>(null);
   const notificationButtonRef = useRef<HTMLButtonElement>(null);
   const showToast = useToastStore((state) => state.showToast);
-  const accessToken = useAuthStore(state => state.accessToken)
+  const accessToken = useAuthStore((state) => state.accessToken);
 
   useEffect(() => {
     // 1. 이벤트 리스너 설정
     const eventListeners = new Map([
-      ['mousedown', handleClickOutside],
       ['newNotification', handleNewNotification],
       ['websocketConnected', () => setIsConnecting(false)],
       ['websocketDisconnected', () => setIsConnecting(true)],
@@ -91,16 +90,6 @@ const Header = () => {
       webSocketService.disconnect();
     };
   }, []); // 컴포넌트 마운트 시 한 번만 실행
-
-  const handleClickOutside = (event: MouseEvent) => {
-    if (
-      isMenuOpen &&
-      buttonRef.current &&
-      !buttonRef.current.contains(event.target as Node)
-    ) {
-      setIsMenuOpen(false);
-    }
-  };
 
   const handleNewNotification = () => {
     setHasUnreadNotifications(true);
@@ -242,7 +231,11 @@ const Header = () => {
                 className='w-8 h-8'
               />
             </button>
-            <HiddenMenu isOpen={isMenuOpen} />
+            <HiddenMenu
+              isOpen={isMenuOpen}
+              onClose={() => setIsMenuOpen(false)}
+              buttonRef={buttonRef}
+            />
           </div>
         </nav>
       </header>

--- a/src/components/header/menus/HiddenMenu.tsx
+++ b/src/components/header/menus/HiddenMenu.tsx
@@ -3,17 +3,31 @@ import { Link, useNavigate } from 'react-router-dom';
 import { logoutAPI } from '@apis/auth';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useUserStore } from '../../../store/useUserStore';
+import { useClickOutside } from '../../../hooks/useClickOutside';
+
 interface HiddenMenuProps {
   isOpen: boolean;
+  onClose: () => void;
+  buttonRef: React.RefObject<HTMLButtonElement>;
 }
-const HiddenMenu = ({ isOpen }: HiddenMenuProps) => {
+
+const HiddenMenu = ({ isOpen, onClose, buttonRef }: HiddenMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const { user } = useUserStore();
+
+  useClickOutside({
+    modalRef: menuRef,
+    buttonRef,
+    isOpen,
+    onClose,
+  });
+
   const handleLogout = async () => {
     await logoutAPI();
     navigate('/login');
   };
+
   return (
     <AnimatePresence>
       {isOpen && (

--- a/src/pages/bookcase/components/ToolBoxButton.tsx
+++ b/src/pages/bookcase/components/ToolBoxButton.tsx
@@ -46,7 +46,7 @@ const ToolBoxButton = ({
       ref={menuRef}
       className={`bottom-menu ${
         isOtherUserBookcase ? 'bottom-20' : 'bottom-20'
-      } right-21 drop-shadow-logo ${
+      } right-21 max-sm:bottom-16 max-sm:right-16 drop-shadow-logo ${
         isOpen && !isOtherUserBookcase ? 'h-[202px]' : 'h-16'
       }`}>
       <div className='flex relative flex-col-reverse gap-5 items-center w-full h-full'>

--- a/src/pages/room/components/DockMenu.tsx
+++ b/src/pages/room/components/DockMenu.tsx
@@ -6,7 +6,11 @@ import preferenceIcon from '@assets/room/preferenceIcon.svg';
 import themeNoselectIcon from '@assets/room/theme-noselect-Icon.svg';
 import themeIcon from '@assets/room/themeIcon.svg';
 
-export default function DockMenu({ activeSettings, onSettingsChange, resetState }: DockMenuProps) {
+export default function DockMenu({
+  activeSettings,
+  onSettingsChange,
+  resetState,
+}: DockMenuProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [hasSelectedSetting, setHasSelectedSetting] = useState<boolean>(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -40,7 +44,7 @@ export default function DockMenu({ activeSettings, onSettingsChange, resetState 
   }, [activeSettings]);
 
   const getCurrentIcon = () => {
-    if (!hasSelectedSetting ) return dockMenuIcon;
+    if (!hasSelectedSetting) return dockMenuIcon;
     if (isOpen) return dockMenuNoselectIcon;
     if (activeSettings === 'preference' && !isOpen) return preferenceIcon;
     if (activeSettings === 'theme' && !isOpen) return themeIcon;
@@ -86,7 +90,7 @@ export default function DockMenu({ activeSettings, onSettingsChange, resetState 
   return (
     <div
       ref={menuRef}
-      className={`bottom-menu bottom-20 right-21 drop-shadow-logo relative ${
+      className={`bottom-menu bottom-20 right-21 max-sm:bottom-16 max-sm:right-16 drop-shadow-logo relative ${
         isOpen ? 'h-[202px]' : 'h-16'
       }`}>
       <div className='relative flex flex-col-reverse items-center w-full h-full gap-5'>


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Fix/Header-42` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- 메뉴 / 테마 / 도서 메뉴 버튼 위치 통일
- 헤더 숨김 메뉴 바깥 영역 클릭에 닫힘 기능 추가

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] HiddenMenu 컴포넌트에 useClickOutside 훅 적용하여 외부 클릭 시 닫힘 기능 추가
- [x] DockMenu 컴포넌트, ToolBoxButton 컴포넌트에 반응형 스타일 max-sm:bottom-16 max-sm:right-16 추가
- [x] 메뉴 버튼들의 위치를 모바일에서 통일 (bottom-16 right-16)

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#42 