### PR TITLE
[Style/GuestBook-mobile-60] 💄 Style: 아이폰 XR 사이즈까지 반응형 추가

### DIFF
--- a/src/pages/room/components/Guestbook.tsx
+++ b/src/pages/room/components/Guestbook.tsx
@@ -94,7 +94,7 @@ export default function Guestbook({
       transition={{ type: 'spring', stiffness: 130, damping: 18 }}
       onClick={handleClickOutside}
       className='fixed inset-0 z-10 flex items-center justify-center'>
-      <div className='@container relative w-[95vw] h-[95vw] max-w-none max-h-none min-w-0 min-h-0 sm:w-[calc(100vw*0.3966)] sm:max-w-[800px] sm:h-[calc(100vw*0.3611)] sm:max-h-[700px] sm:min-w-[600px] sm:min-h-[550px] '>
+      <div className='@container relative w-[95vw] h-[95vw] max-w-none max-h-none min-w-0 min-h-0 sm:w-[calc(100vw*0.3966)] sm:max-w-[800px] sm:h-[calc(100vw*0.3611)] sm:max-h-[700px] sm:min-w-[600px] sm:min-h-[550px] max-[560px]:h-[100vw]'>
         {/* 뒤 배경 */}
         <div className='guest-book-background bottom-[-30px] absolute w-full h-full bg-[#73A1F7] max-sm:max-h-[45.875vw] max-sm:min-h-[45.875vw] !rounded-[50px] sm:!rounded-[60px] border-2 border-[#2656CD]'></div>
 
@@ -115,7 +115,7 @@ export default function Guestbook({
         </div>
 
         {/* 메인 배경 */}
-        <section className='guest-book flex-col items-center pt-6 sm:pt-10 @2xl:pt-15 px-6 sm:px-13 @2xl:px-16 @3xl:gap-4 max-sm:rounded-[60px] max-sm:!w-full '>
+        <section className='guest-book flex-col items-center pt-6 sm:pt-10 @2xl:pt-15 px-6 sm:px-13 @2xl:px-16 @3xl:gap-4 max-sm:rounded-[60px] max-sm:!w-full max-[560px]:h-[100vw]'>
           {/* 방명록 컨텐츠 */}
           <span className='flex gap-2 font-bold text-2xl @xl:text-3xl @2xl:text-4xl @2xl:my-3'>
             <p className='text-[#4983EF]'>{ownerName}</p>

--- a/src/pages/room/components/Guestbook.tsx
+++ b/src/pages/room/components/Guestbook.tsx
@@ -94,7 +94,7 @@ export default function Guestbook({
       transition={{ type: 'spring', stiffness: 130, damping: 18 }}
       onClick={handleClickOutside}
       className='fixed inset-0 z-10 flex items-center justify-center'>
-      <div className='@container relative w-[95vw] h-[95vw] max-w-none max-h-none min-w-0 min-h-0 sm:w-[calc(100vw*0.3966)] sm:max-w-[800px] sm:h-[calc(100vw*0.3611)] sm:max-h-[700px] sm:min-w-[600px] sm:min-h-[550px] max-[560px]:h-[100vw]'>
+      <div className='@container relative w-[95vw] h-[95vw] max-w-none max-h-none min-w-0 min-h-0 sm:w-[calc(100vw*0.3966)] sm:max-w-[800px] sm:h-[calc(100vw*0.3611)] sm:max-h-[700px] sm:min-w-[600px] sm:min-h-[550px] max-[560px]:h-[100vw] max-[525px]:h-[115vw] max-[480px]:h-[135vw]'>
         {/* 뒤 배경 */}
         <div className='guest-book-background bottom-[-30px] absolute w-full h-full bg-[#73A1F7] max-sm:max-h-[45.875vw] max-sm:min-h-[45.875vw] !rounded-[50px] sm:!rounded-[60px] border-2 border-[#2656CD]'></div>
 
@@ -115,7 +115,7 @@ export default function Guestbook({
         </div>
 
         {/* 메인 배경 */}
-        <section className='guest-book flex-col items-center pt-6 sm:pt-10 @2xl:pt-15 px-6 sm:px-13 @2xl:px-16 @3xl:gap-4 max-sm:rounded-[60px] max-sm:!w-full max-[560px]:h-[100vw]'>
+        <section className='guest-book flex-col items-center pt-6 sm:pt-10 @2xl:pt-15 px-6 sm:px-13 @2xl:px-16 @3xl:gap-4 max-sm:rounded-[60px] max-sm:!w-full max-[560px]:h-[100vw] max-[525px]:h-[115vw]'>
           {/* 방명록 컨텐츠 */}
           <span className='flex gap-2 font-bold text-2xl @xl:text-3xl @2xl:text-4xl @2xl:my-3'>
             <p className='text-[#4983EF]'>{ownerName}</p>

--- a/src/pages/room/components/GuestbookMessage.tsx
+++ b/src/pages/room/components/GuestbookMessage.tsx
@@ -48,7 +48,7 @@ export default function GuestbookMessage({
   };
 
   return (
-    <div className='guest-book-content @container w-full flex flex-col gap-2 2xl:gap-4 mt-3 mb-2 2xl:mb-3 3xl:mb-8 max-h-[300px] sm:max-h-80 min-h-[300px] sm:min-h-[300px] max-sm:max-h-[45.875vw] max-sm:min-h-[45.875vw] max-sm:mt-8'>
+    <div className='guest-book-content @container w-full flex flex-col gap-2 2xl:gap-4 mt-3 mb-2 2xl:mb-3 3xl:mb-8 max-h-[300px] sm:max-h-80 min-h-[300px] sm:min-h-[300px] max-sm:max-h-[45.875vw] max-sm:min-h-[45.875vw] max-sm:mt-8 max-[560px]:mb-6'>
       {/* 방명록 글 0개일 경우 */}
       {messages.length === 0 ? (
         <div className='flex flex-col justify-center items-center text-gray-500/50 h-50 @lg:h-74 @xl:h-96 font-medium'>
@@ -66,7 +66,7 @@ export default function GuestbookMessage({
             key={msg.guestbookId}
             className={`flex items-center bg-[#F5F1FA]/40 rounded-xl @xl:rounded-3xl w-full py-5 gap-8 @xl:gap-11 px-8 @xl:px-12`}>
             {/* 방명록 컨텐츠 */}
-            <div className='flex flex-col flex-1 min-h-[100px] justify-between '>
+            <div className='flex flex-col flex-1 min-h-[100px] justify-between w-full'>
               <div className='flex justify-between items-center w-full mb-2 @xl:mb-4'>
                 {/* 관계 */}
                 <p
@@ -109,7 +109,7 @@ export default function GuestbookMessage({
               </div>
 
               {/* 방명록 본문 */}
-              <p className='text-xs @xl:text-sm text-[#292929]/70 font-medium mb-2 ml-[2px] leading-tight '>
+              <p className='text-xs @xl:text-sm text-[#292929]/70 font-medium mb-2 ml-[2px] leading-tight w-full break-words whitespace-pre-wrap'>
                 {msg.message}
               </p>
 

--- a/src/pages/room/components/GuestbookMessage.tsx
+++ b/src/pages/room/components/GuestbookMessage.tsx
@@ -48,7 +48,7 @@ export default function GuestbookMessage({
   };
 
   return (
-    <div className='guest-book-content @container w-full flex flex-col gap-2 2xl:gap-4 mt-3 mb-2 2xl:mb-3 3xl:mb-8 max-h-[300px] sm:max-h-80 min-h-[300px] sm:min-h-[300px] max-sm:max-h-[45.875vw] max-sm:min-h-[45.875vw] max-sm:mt-8 max-[560px]:mb-6'>
+    <div className='guest-book-content @container w-full flex flex-col gap-2 2xl:gap-4 mt-3 mb-2 2xl:mb-3 3xl:mb-8 max-h-[300px] sm:max-h-80 min-h-[300px] sm:min-h-[300px] max-sm:max-h-[45.875vw] max-sm:min-h-[45.875vw] max-sm:mt-8 max-[560px]:mb-6 max-[480px]:mt-4'>
       {/* 방명록 글 0개일 경우 */}
       {messages.length === 0 ? (
         <div className='flex flex-col justify-center items-center text-gray-500/50 h-50 @lg:h-74 @xl:h-96 font-medium'>

--- a/src/pages/room/components/GusetbookInput.tsx
+++ b/src/pages/room/components/GusetbookInput.tsx
@@ -58,7 +58,7 @@ export default function GusetbookInput({ onSubmitMessage }) {
   return (
     <form
       ref={formRef}
-      className='@container flex items-start w-full mb-0 gap-2 relative'
+      className='@container guest-book-form flex items-start w-full mb-0 gap-2 relative max-[640px]:mb-3 max-[640px]:mt-[5vw]'
       aria-label='방명록 작성'
       onSubmit={handleSubmit}>
       {/* 글자 수 표시 */}

--- a/src/pages/room/components/GusetbookInput.tsx
+++ b/src/pages/room/components/GusetbookInput.tsx
@@ -58,7 +58,7 @@ export default function GusetbookInput({ onSubmitMessage }) {
   return (
     <form
       ref={formRef}
-      className='@container guest-book-form flex items-start w-full mb-0 gap-2 relative max-[640px]:mb-3 max-[640px]:mt-[5vw]'
+      className='@container guest-book-form flex items-start w-full mb-0 gap-2 relative max-[640px]:mb-3 max-[640px]:mt-[5vw] max-[525px]:mt-[10vw] max-[500px]:mt-[15vw]  max-[480px]:mt-[18vw]  max-[460px]:mt-[20vw]  max-[440px]:mt-[24vw] max-[420px]:mt-[28vw] max-[420px]:mb-0'
       aria-label='방명록 작성'
       onSubmit={handleSubmit}>
       {/* 글자 수 표시 */}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -109,6 +109,15 @@
   }
 }
 
+@media (max-width: 560px) {
+  .guest-book {
+    width: 95vw;
+    height: 100vw;
+    max-width: none;
+    max-height: none;
+  }
+}
+
 .guest-book-background {
   max-width: 800px;
   max-height: 700px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -118,6 +118,23 @@
   }
 }
 
+@media (max-width: 525px) {
+  .guest-book {
+    width: 95vw;
+    height: 115vw;
+    max-width: none;
+    max-height: none;
+  }
+}
+@media (max-width: 480px) {
+  .guest-book {
+    width: 95vw;
+    height: 135vw;
+    max-width: none;
+    max-height: none;
+  }
+}
+
 .guest-book-background {
   max-width: 800px;
   max-height: 700px;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -129,6 +129,10 @@
       width: 28px;
       height: 64px;
     }
+
+    /* .guest-book-form {
+      margin-bottom: 24px;
+    } */
   }
 
   @media (min-width: 1536px) {


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Style/GuestBook-mobile-60` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- 아이폰 XR 사이즈까지 반응형이 되도록 수정

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
<img width="826" height="1790" alt="image" src="https://github.com/user-attachments/assets/eb27a84a-b0e3-4066-a630-d6f7b7b919c3" />

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 추후 개선 포인트
- guest-book-content과 guest-book-form가 묶여있지 않아 모바일 구간을 5~6개 구간마다 따로 css 코드를 추가했습니다
  -> DOM 구조 개편 필요
- 모바일에서 180자 기준 2개의 컨텐츠를 한 페이지에 렌더링하기 위해 구조를 세로형으로 수정
  -> 정방형 레이아웃을 유지하기 위해서는 너비에 따라 Data fetch 구조 수정 필요

+) 추후 개선시 요소를 모두 DOM 구조로 구현하기 보다는 svg 이미지를 쓰는 게 좋을 것 같습니다

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#60