### PR TITLE
[Fix/GA-tag-62] 🚨 Fix: 페이지별 사용량 추적 hook 수정, 항목 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,8 @@ import { Toast } from '@components/Toast';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // utils
-import { initGA, trackEvent } from '@utils/ga';
+import { initGA, trackEvent, trackTestEvent } from '@utils/ga';
 import PageTracker from './components/PageTracker';
-
 
 function App() {
   useEffect(() => {
@@ -21,7 +20,14 @@ function App() {
       // 세션 시작 추적
       trackEvent('session_start', {
         event_category: 'user_engagement',
-      })
+      });
+
+      // 테스트 이벤트 (개발 환경에서만 실행)
+      if (import.meta.env.DEV) {
+        setTimeout(() => {
+          trackTestEvent();
+        }, 5000);
+      }
 
       // 유입 경로 추적
       const referrer = document.referrer || 'direct';
@@ -35,23 +41,23 @@ function App() {
           : referrer !== 'direct'
           ? 'referral'
           : 'direct',
-      })
+      });
 
       // 세션 종료 추적
       const startTime = Date.now();
       const handleBeforeUnload = () => {
-        const duration = ~~((Date.now() - startTime)/1000)
+        const duration = ~~((Date.now() - startTime) / 1000);
         trackEvent('session_duration', {
           event_category: 'engagement',
           session_duration_sec: duration,
           pages_visited: window.history.length,
           last_visit: new Date().toISOString(),
-        })
+        });
       };
       window.addEventListener('beforeunload', handleBeforeUnload);
       return () => {
         window.removeEventListener('beforeunload', handleBeforeUnload);
-      }
+      };
     } else {
       console.warn('GA_MEASUREMENT_ID가 설정되지 않았습니다.');
     }

--- a/src/hooks/useBackofficeBatchTracking.ts
+++ b/src/hooks/useBackofficeBatchTracking.ts
@@ -148,6 +148,9 @@ const createBatchManager = () => {
       user_patterns: analytics.userPatterns,
       timestamp: new Date().toISOString(),
       batch_id: Date.now().toString(),
+      feature_name: analytics.uniqueFeatures.join(','),
+      user_id: analytics.uniqueUsers.join(','),
+      session_id: Date.now().toString(),
     });
 
     console.log('📊 백오피스 배치 데이터 전송:', {

--- a/src/pages/book/book-editor/BookEditorPage.tsx
+++ b/src/pages/book/book-editor/BookEditorPage.tsx
@@ -17,6 +17,7 @@ import {
   useAutoBackofficeTracking,
   useBackofficeFeatureTracking,
 } from '@/hooks/useBackofficeBatchTracking';
+import { trackEvent } from '@/utils/ga';
 
 interface BookEditorPageProps {
   bookTitle: string;
@@ -50,7 +51,17 @@ const BookEditorPage = ({
   // endTracking 함수 메모이제이션
   const memoizedEndTracking = useCallback(() => {
     endTracking();
-  }, [endTracking]);
+
+    // 개별 이벤트 전송
+    trackEvent('backoffice_feature_analytics', {
+      feature_name: 'book_editor',
+      user_id: user?.userId?.toString() || 'anonymous',
+      session_id: Date.now().toString(),
+      event_type: 'review_completed',
+      book_title: bookTitle,
+      timestamp: new Date().toISOString(),
+    });
+  }, [endTracking, user?.userId, bookTitle]);
 
   // bookInfo 객체 메모이제이션
   const bookInfo = useMemo(

--- a/src/pages/bookcase/BookCasePage.tsx
+++ b/src/pages/bookcase/BookCasePage.tsx
@@ -15,6 +15,7 @@ import {
   useAutoBackofficeTracking,
   useBackofficeFeatureTracking,
 } from '@/hooks/useBackofficeBatchTracking';
+import { trackEvent } from '@/utils/ga';
 
 const BookCasePage = () => {
   const { showToast } = useToastStore();
@@ -278,6 +279,16 @@ const BookCasePage = () => {
               setIsModalOpen(false);
 
               endBookAddTracking();
+
+              // 개별 이벤트 전송
+              trackEvent('backoffice_feature_analytics', {
+                feature_name: 'book',
+                user_id: user?.userId?.toString() || 'anonymous',
+                session_id: Date.now().toString(),
+                event_type: 'book_added',
+                book_title: newBook.title,
+                timestamp: new Date().toISOString(),
+              });
             } catch (error) {
               console.error('책 추가에 실패했습니다:', error);
               setBooks((prevBooks) =>

--- a/src/pages/room/components/GusetbookInput.tsx
+++ b/src/pages/room/components/GusetbookInput.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import LayeredButton from '../../../components/LayeredButton';
 import { useBackofficeFeatureTracking } from '@/hooks/useBackofficeBatchTracking';
+import { trackEvent } from '@/utils/ga';
 import { useUserStore } from '@/store/useUserStore';
 
 export default function GusetbookInput({ onSubmitMessage }) {
@@ -28,6 +29,15 @@ export default function GusetbookInput({ onSubmitMessage }) {
 
       // 작성 완료 시 추적 종료
       endTracking();
+
+      // 개별 이벤트 전송
+      trackEvent('backoffice_feature_analytics', {
+        feature_name: 'guestbook_writing',
+        user_id: user?.userId?.toString() || 'anonymous',
+        session_id: Date.now().toString(),
+        event_type: 'completion',
+        timestamp: new Date().toISOString(),
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/src/pages/room/components/ThemeSetting.tsx
+++ b/src/pages/room/components/ThemeSetting.tsx
@@ -6,6 +6,7 @@ import { useClickOutside } from '../../../hooks/useClickOutside';
 import { useToastStore } from '../../../store/useToastStore';
 import { useUserStore } from '../../../store/useUserStore';
 import { useBackofficeFeatureTracking } from '../../../hooks/useBackofficeBatchTracking';
+import { trackEvent } from '../../../utils/ga';
 import ThemeSettingCard from './ThemeSettingCard';
 
 export default function ThemeSetting({
@@ -126,6 +127,16 @@ export default function ThemeSetting({
                 } else {
                   endTracking();
                   onThemeSelect(theme as 'BASIC' | 'FOREST' | 'MARINE');
+
+                  // 개별 이벤트 전송
+                  trackEvent('backoffice_feature_analytics', {
+                    feature_name: 'room_theme_setting',
+                    user_id: user?.userId?.toString() || 'anonymous',
+                    session_id: Date.now().toString(),
+                    event_type: 'theme_selected',
+                    selected_theme: theme,
+                    timestamp: new Date().toISOString(),
+                  });
                 }
               }}
             />


### PR DESCRIPTION
## ✨ 반영 브랜치
`Fix/GA-tag-62` -> `dev`

## 📝 설명
GA 커스텀 이벤트 전송 문제 해결

## ✅ 변경 사항
- [x] GA 이벤트 전송 로직 강화 (gtag + dataLayer fallback)
- [x] `backoffice_feature_analytics` 이벤트에 필수 3개 항목 추가
  - `feature_name`: 기능명 목록
  - `user_id`: 사용자 ID 목록  
  - `session_id`: 배치 세션 ID
  - `이벤트 전송`: gtag 실패 시 dataLayer 직접 추가하는 fallback 로직

## 📢 이슈 정보
close #62 