### PR TITLE
📝 Chore: 커스텀 이벤트 항목 중 userid 부분 커스텀 파라미터로 변경

### DIFF
--- a/src/hooks/useBackofficeBatchTracking.ts
+++ b/src/hooks/useBackofficeBatchTracking.ts
@@ -149,7 +149,7 @@ const createBatchManager = () => {
       timestamp: new Date().toISOString(),
       batch_id: Date.now().toString(),
       feature_name: analytics.uniqueFeatures.join(','),
-      user_id: analytics.uniqueUsers.join(','),
+      custom_user_id: analytics.uniqueUsers.join(','),
       session_id: Date.now().toString(),
     };
 

--- a/src/pages/book/book-editor/BookEditorPage.tsx
+++ b/src/pages/book/book-editor/BookEditorPage.tsx
@@ -55,7 +55,7 @@ const BookEditorPage = ({
     // 개별 이벤트 전송
     trackEvent('backoffice_feature_analytics', {
       feature_name: 'book_editor',
-      user_id: user?.userId?.toString() || 'anonymous',
+      custom_user_id: user?.userId?.toString() || 'anonymous',
       session_id: Date.now().toString(),
       event_type: 'review_completed',
       book_title: bookTitle,

--- a/src/pages/bookcase/BookCasePage.tsx
+++ b/src/pages/bookcase/BookCasePage.tsx
@@ -283,7 +283,7 @@ const BookCasePage = () => {
               // 개별 이벤트 전송
               trackEvent('backoffice_feature_analytics', {
                 feature_name: 'book',
-                user_id: user?.userId?.toString() || 'anonymous',
+                custom_user_id: user?.userId?.toString() || 'anonymous',
                 session_id: Date.now().toString(),
                 event_type: 'book_added',
                 book_title: newBook.title,

--- a/src/pages/room/components/GusetbookInput.tsx
+++ b/src/pages/room/components/GusetbookInput.tsx
@@ -33,7 +33,7 @@ export default function GusetbookInput({ onSubmitMessage }) {
       // 개별 이벤트 전송
       trackEvent('backoffice_feature_analytics', {
         feature_name: 'guestbook_writing',
-        user_id: user?.userId?.toString() || 'anonymous',
+        custom_user_id: user?.userId?.toString() || 'anonymous',
         session_id: Date.now().toString(),
         event_type: 'completion',
         timestamp: new Date().toISOString(),

--- a/src/pages/room/components/ThemeSetting.tsx
+++ b/src/pages/room/components/ThemeSetting.tsx
@@ -131,7 +131,7 @@ export default function ThemeSetting({
                   // 개별 이벤트 전송
                   trackEvent('backoffice_feature_analytics', {
                     feature_name: 'room_theme_setting',
-                    user_id: user?.userId?.toString() || 'anonymous',
+                    custom_user_id: user?.userId?.toString() || 'anonymous',
                     session_id: Date.now().toString(),
                     event_type: 'theme_selected',
                     selected_theme: theme,

--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -65,7 +65,7 @@ export const initGA = (measurementId: string, userId?: string) => {
  * 커스텀 이벤트 전송
  * @param eventName - 이벤트 이름 (예: 'button_click', 'page_view')
  * @param parameters - 이벤트 파라미터 객체
- * @param parameters.user_id - 로그인한 사용자의 아이디 (자동 추가됨)
+ * @param parameters.custom_user_id - 로그인한 사용자의 아이디 (자동 추가됨)
  * @param parameters.timestamp - 이벤트 발생 시간 (자동 추가됨)
  * @param parameters.event_category - 이벤트 카테고리 (선택사항)
  * @param parameters.event_label - 이벤트 라벨 (선택사항)
@@ -86,7 +86,7 @@ export const trackEvent = (
     if (window.gtag) {
       window.gtag('event', eventName, {
         ...parameters,
-        user_id: currentUserId, // 모든 이벤트에 user_id 추가
+        custom_user_id: currentUserId, // 모든 이벤트에 custom_user_id 추가
         timestamp: new Date().toISOString(),
       });
       console.log('GA Event tracked (gtag):', eventName, parameters);
@@ -95,7 +95,7 @@ export const trackEvent = (
       window.dataLayer.push({
         event: eventName,
         ...parameters,
-        user_id: currentUserId, // 모든 이벤트에 user_id 추가
+        custom_user_id: currentUserId, // 모든 이벤트에 custom_user_id 추가
         timestamp: new Date().toISOString(),
       });
       console.log('GA Event tracked (dataLayer):', eventName, parameters);

--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -45,20 +45,28 @@ export const initGA = (measurementId: string, userId?: string) => {
   script1.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
   document.head.appendChild(script1);
 
+  // gtag 초기화 스크립트
   const script2 = document.createElement('script');
   script2.innerHTML = `
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', '${measurementId}', {
-      page_title: document.title,
-      page_location: window.location.href,
-      send_page_view: true,
-      debug_mode: true,
-      user_id: '${userId || 'anonymous'}'
-    });
   `;
   document.head.appendChild(script2);
+
+  // gtag가 로드된 후 config 호출
+  script1.onload = () => {
+    if (window.gtag) {
+      window.gtag('config', measurementId, {
+        page_title: document.title,
+        page_location: window.location.href,
+        send_page_view: true,
+        debug_mode: true,
+        user_id: userId || 'anonymous',
+      });
+      console.log('GA Config 설정 완료:', measurementId, 'User ID:', userId);
+    }
+  };
 };
 
 /**


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Fix/GA-tag-62` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
GA 초기화시 config 
모든 곳에서 `user_id` → `custom_user_id`로 변경

### 변경된 파일들
1. `GusetbookInput.tsx`: 방명록 작성 이벤트
2. `ThemeSetting.tsx`: 방 테마 선택 이벤트  
3. `BookCasePage.tsx`: 도서 추가 이벤트
4. `BookEditorPage.tsx`: 도서 편집 이벤트
5. `useBackofficeBatchTracking.ts`: 배치 전송 이벤트

공통 파라미터를 다음과 같이 수정
- **`user_id`**: GA config에만 설정
- **`custom_user_id`**: 모든 커스텀 이벤트에 포함

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#62