### PR TITLE
[Fix/cdrack-85] 🚨 Fix: 조건 렌더링 및 스타일링 수정 & 최소 8개의 CD 유지

### DIFF
--- a/src/pages/cdrack/CdRackPage.tsx
+++ b/src/pages/cdrack/CdRackPage.tsx
@@ -15,7 +15,7 @@ import useCdRackData from './hooks/useCdRackData';
 export default function CdRackPage() {
   const { userId: myUserId } = useUserStore().user;
   const { userId } = useParams();
-  const targetUserId = Number(userId) || 1;
+  const targetUserId = Number(userId);
   const {
     items,
     initialLoading,
@@ -52,6 +52,8 @@ export default function CdRackPage() {
     setTimeout(() => setResetDockMenuState(false), 0);
   };
 
+  console.log('myUserId:', myUserId, 'targetUserId:', targetUserId);
+
   const isEmpty = !items || items.length === 0;
 
   return (
@@ -59,10 +61,12 @@ export default function CdRackPage() {
       <div className=' w-full h-screen bg-[#516392cc] backdrop-blur-[35px] '>
         {isEmpty ? (
           <div className='absolute inset-0 flex flex-col items-center justify-center'>
-            <TypingText
-              text='  꽂을 CD가 없네요...'
-              className='text-base lg:text-[30px] font-bold text-white/70 mb-6'
-            />
+            <div className='mb-6 h-[40px] lg:h-[60px] flex items-center'>
+              <TypingText
+                text='꽂을 CD가 없네요...'
+                className='text-base lg:text-[30px] font-bold text-white/70'
+              />
+            </div>
             <img
               className='w-48 lg:w-[472px] aspect-square drop-shadow-book hover:animate-slowSpin'
               src={cd}
@@ -73,36 +77,35 @@ export default function CdRackPage() {
           <>
             <CdRack
               items={items}
-              isModalOpen={isModalOpen} 
+              isModalOpen={isModalOpen}
             />
             <CdHoverLabel />
-
-            {/* 독메뉴 */}
-            {myUserId === targetUserId && (
-              <CdDockMenu
-                activeSettings={activeSettings}
-                onSettingsChange={handleSettingsChange}
-                resetState={resetDockMenuState}
-              />
-            )}
-
-            {/* 서치모달 / 삭제 모달 */}
-            {activeSettings === 'add' && (
-              <SearchModal
-                title='CD 랙에 담을 음악 찾기'
-                onClose={handleCloseSettings}
-                type='CD'
-                onSelect={(cdItem) => addCd(cdItem)}
-              />
-            )}
-            {activeSettings === 'delete' && (
-              <CdDeleteModal
-                items={items}
-                onClose={handleCloseSettings}
-                onDelete={(ids) => deleteCd(ids)}
-              />
-            )}
           </>
+        )}
+        {/* 독메뉴 */}
+        {myUserId === targetUserId && (
+          <CdDockMenu
+            activeSettings={activeSettings}
+            onSettingsChange={handleSettingsChange}
+            resetState={resetDockMenuState}
+          />
+        )}
+
+        {/* 서치모달 / 삭제 모달 */}
+        {activeSettings === 'add' && (
+          <SearchModal
+            title='CD 랙에 담을 음악 찾기'
+            onClose={handleCloseSettings}
+            type='CD'
+            onSelect={(cdItem) => addCd(cdItem)}
+          />
+        )}
+        {activeSettings === 'delete' && (
+          <CdDeleteModal
+            items={items}
+            onClose={handleCloseSettings}
+            onDelete={(ids) => deleteCd(ids)}
+          />
         )}
       </div>
     </div>

--- a/src/pages/cdrack/CdRackPage.tsx
+++ b/src/pages/cdrack/CdRackPage.tsx
@@ -52,8 +52,6 @@ export default function CdRackPage() {
     setTimeout(() => setResetDockMenuState(false), 0);
   };
 
-  console.log('myUserId:', myUserId, 'targetUserId:', targetUserId);
-
   const isEmpty = !items || items.length === 0;
 
   return (

--- a/src/pages/cdrack/components/CdDockMenu.tsx
+++ b/src/pages/cdrack/components/CdDockMenu.tsx
@@ -30,7 +30,7 @@ export default function CdDockMenu({
   return (
     <div
       ref={menuRef}
-      className={`z-5 bottom-menu bottom-20 right-21 max-sm:bottom-16 max-sm:right-16 relative ${
+      className={`z-[5] bottom-menu bottom-20 right-21 max-sm:bottom-16 max-sm:right-16 relative ${
         isOpen ? 'h-[202px]' : 'h-16'
       }`}>
       <div className='relative flex flex-col-reverse items-center w-full h-full gap-5'>

--- a/src/pages/cdrack/components/CdWheel.tsx
+++ b/src/pages/cdrack/components/CdWheel.tsx
@@ -20,24 +20,43 @@ export default function CdWheel({
 
   const phase = useRef(0);
   const phaseVel = useRef(0);
+  
 
   const dir = useMemo(() => cdSettings.DIR.clone(), []);
+
+  const paddedItems: ExtendedCdItem[] = useMemo(() => {
+  const placeholdersNeeded = Math.max(0, 8 - items.length);
+  const placeholders = Array.from({ length: placeholdersNeeded }, (_, i) => ({
+    myCdId: -1000 - i,
+    title: '',
+    artist: '',
+    album: '',
+    releaseDate: '',
+    genres: [],
+    coverUrl: '',
+    youtubeUrl: '',
+    duration: 0,
+    isPlaceholder: true,
+  }));
+  return [...items, ...placeholders];
+}, [items]);
 
   useEffect(() => {
     if (isModalOpen) return; 
 
     const onWheel = (e: WheelEvent) => {
+      if (items.length <= 8) return;
       phaseVel.current += e.deltaY * -0.003;
     };
     window.addEventListener('wheel', onWheel, { passive: true });
     return () => window.removeEventListener('wheel', onWheel);
-  }, [isModalOpen]);
+  }, [isModalOpen, items.length]);
 
   useFrame((_state, dt) => {
     phase.current += phaseVel.current * dt;
     phaseVel.current *= Math.exp(-2.2 * dt);
 
-    const N = items.length;
+    const N = paddedItems.length;
     if (wheel.current) {
       wheel.current.children.forEach((child, i) => {
         const t = wrapCentered(i - phase.current, N);
@@ -48,14 +67,16 @@ export default function CdWheel({
 
     setPhase(phase.current);
   });
+  
 
   return (
+    
       <group
         ref={wheel}
         rotation={cdSettings.WHEEL_ROT}
         position={[-0.5, -0.2, 0]}>
-        {items.map((item: CdItem, i: number) => {
-          const N = items.length;
+        {paddedItems.map((item: CdItem, i: number) => {
+          const N = paddedItems.length;
           const CENTER = (N - 1) * 0.5;
           const base = dir
             .clone()

--- a/src/pages/cdrack/hooks/useCdRackData.ts
+++ b/src/pages/cdrack/hooks/useCdRackData.ts
@@ -124,7 +124,7 @@ const deleteCd = useCallback(
       fetchPage(undefined);
     }
   },
-  [setOptimisticItems, optimisticItems, fetchPage]
+  [setOptimisticItems, optimisticItems, fetchPage, showToast]
 );
 
   const isLoading = initialLoading || isFetchingMore;

--- a/src/types/cd.d.ts
+++ b/src/types/cd.d.ts
@@ -1,5 +1,7 @@
 type CdItem = Pick<CDRackItem, 'myCdId' | 'coverUrl' | 'title' | 'artist' | 'album' | 'releaseDate' | 'genres' | 'youtubeUrl' | 'duration'>
 
+type ExtendedCdItem = CdItem & { isPlaceholder?: boolean };
+
 interface CdRackProps {
   items: CdItem[];
   isModalOpen?: boolean; 


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Fix/cdrack-85` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- 독 메뉴 렌더링 조건 수정 및 최소 3개의 CD 유지 (빈슬롯)

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `CdRackPage.tsx`
  - 조건 분기 안에 들어있던 독 컴포넌트 밖으로 이동

- [x] `CdSet.tsx` & `CdWheel.tsx`
  - 8개 이하 스크롤 이벤트 삭제
  - 최소 8개 CD 유지 ( 빈슬롯으로 해당 갯수는 포함되지 않는다.) 

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- PR에 대해 어떻게 생각하시나요?

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#85 