### PR TITLE
[Fix/cd-95] 💄 Style: 반응형 디자인 추가 & 🚨 Fix: 뒤로 가기로 이동 시 카메라 세팅 문제 해결

### DIFF
--- a/src/pages/cd/CdPage.tsx
+++ b/src/pages/cd/CdPage.tsx
@@ -36,10 +36,14 @@ export default function CdPage() {
 
   return (
     <div
-      className={`flex flex-col justify-between w-full min-h-[100vh] bg-center bg-no-repeat bg-cover`}
+      className={`flex flex-col justify-between w-full h-[100vh] bg-center bg-no-repeat bg-cover overflow-y-auto`}
       style={{ backgroundImage: `url(${backgroundIMG})` }}>
       {/* 템플릿, CD이미지, 댓글 */}
-      <div className='flex justify-center items-end gap-22 h-[87vh] px-22  pt-17 pb-19  '>
+      <div
+        className='grid grid-cols-1 
+    md:[grid-template-columns:minmax(220px,0.5fr)_minmax(240px,0.7fr)_minmax(220px,0.5fr)]
+    gap-10 md:gap-20 px-6 pt-10 md:px-30 md:pt-15
+    pb-[calc(18vh-env(safe-area-inset-bottom))]  '>
         <CdTemplate />
         {hasData ? (
           <CdInfo
@@ -55,13 +59,15 @@ export default function CdPage() {
       </div>
 
       {/* 플레이어 */}
-      <section className='sticky bottom-0 left-0 right-0'>
+      <section
+        className='fixed bottom-0 left-0 right-0 mt-30
+        '>
         <CdPlayer
           cdInfo={cdInfo}
           setCdPlaying={onSetCdPlaying}
           setCurrentTime={setCurrentTime}
         />
-        <div className='h-[enc(safe-area-inset-bottom)]'/>
+        <div className='h-[env(safe-area-inset-bottom)]' />
       </section>
     </div>
   );

--- a/src/pages/cd/components/CdInfo.tsx
+++ b/src/pages/cd/components/CdInfo.tsx
@@ -18,7 +18,8 @@ export const CdInfo = React.memo(
       };
     }, []);
     return (
-      <section className='w-[36%] h-full flex flex-col gap-10 items-center justify-between pt-20 '>
+      <section
+        className='order-1 md:order-2 flex flex-col h-full items-center justify-center gap-4 md:gap-6'>
         <article className='text-white flex flex-col gap-1.5 text-center '>
           <span className='2xl:text-2xl  text-xl font-semibold opacity-70'>
             {cdInfo?.artist}
@@ -31,14 +32,37 @@ export const CdInfo = React.memo(
           </h1>
         </article>
 
-        <article className='w-full  relative'>
-          <div className='relative w-full max-w-[550px] aspect-square mx-auto'>
+        <article className='w-full relative'>
+          <div className='relative w-full max-w-full aspect-square mx-auto'>
             <img
-              className={`absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-[5] w-[70%] ${
+              className={`absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-[6] w-[70%] ${
                 cdPlaying && 'animate-spin'
-              } `}
+              }`}
+              src={cdInfo.coverUrl}
+              alt='앨범 커버'
+              style={{
+                WebkitMaskImage: `url(${cd})`,
+                WebkitMaskRepeat: 'no-repeat',
+                WebkitMaskSize: 'cover',
+                maskImage: `url(${cd})`,
+                maskRepeat: 'no-repeat',
+                maskSize: 'cover',
+                animationDuration: '6s',
+              }}
+            />
+
+            {/* CD 질감 */}
+            <img
+              className={`absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-[7] w-[70%] pointer-events-none ${
+                cdPlaying && 'animate-spin'
+              }`}
               src={cd}
-              alt='cd 이미지'
+              alt='CD 텍스처'
+              style={{
+                animationDuration: '6s',
+                mixBlendMode: 'overlay', // 핵심! multiply/overlay/screen 중 택1
+                opacity: 0.9, // 투명도로 강도 조절
+              }}
             />
             <img
               className='w-full h-full object-contain'

--- a/src/pages/cd/components/comments/CdComment.tsx
+++ b/src/pages/cd/components/comments/CdComment.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
+import CommentListButton from './CommentListButton';
 import CommentListModal from './CommentListModal';
 import VisibleCommentList from './VisibleCommentList';
-import CommentListButton from './CommentListButton';
 
 export default function CdComment({ currentTime }: { currentTime: number }) {
   const [isCommentListOpen, setIsCommentListOpen] = useState(false);
@@ -12,7 +12,8 @@ export default function CdComment({ currentTime }: { currentTime: number }) {
 
   return (
     <>
-      <div className=' w-[32%] h-full  rounded-3xl border-2 border-[#FCF7FD]  bg-[#3E507D40] shadow-box backdrop-blur-lg relative'>
+      <div
+        className='h-full rounded-3xl border-2 border-[#FCF7FD] bg-[#3E507D40] shadow-box backdrop-blur-lg relative order-3 md:order-3 w-full  mx-auto md:mx-0'>
         {/* 댓글 목록 보기 버튼 */}
         <CommentListButton setCommentListOpen={setIsCommentListOpen} />
         <div className='flex flex-col gap-6 justify-end items-end px-7 pt-14 pb-6 w-full h-full'>

--- a/src/pages/cd/components/comments/CommentListModal.tsx
+++ b/src/pages/cd/components/comments/CommentListModal.tsx
@@ -28,8 +28,9 @@ const CommentListModal = React.memo(({ onClose }: { onClose: () => void }) => {
             duration: 0.2,
             ease: 'easeOut',
           }}
-          className='w-[662px] h-[690px] rounded-3xl border-2 border-[#FCF7FD] shadow-box  backdrop-blur-[15px] p-4  '>
-          <div className='w-full  h-full bg-[#FCF7FD] rounded-[16px]  backdrop-blur-[15px] py-10 px-27'>
+          className='w-[90vw] max-w-[662px] h-[80vh] max-h-[690px] rounded-3xl border-2 border-[#FCF7FD]
+    shadow-box backdrop-blur-[15px] p-4 overflow-y-auto  '>
+          <div className='w-full  h-full bg-[#FCF7FD] rounded-[16px]  backdrop-blur-[15px] py-10 px-7 md:py-10 md:px-27'>
             <h1 className='text-[#7838AF]  text-2xl font-bold text-center mb-7'>
               댓글 목록
             </h1>

--- a/src/pages/cd/components/player/LeftGroup.tsx
+++ b/src/pages/cd/components/player/LeftGroup.tsx
@@ -22,14 +22,7 @@ const LeftGroup = React.memo(
     handleMuteCdVolume,
   }: LeftProps) => {
     return (
-      <article className='flex flex-1 gap-14 items-center h-full'>
-        {/* 앨범 이미지 */}
-        <img
-          className='block h-full aspect-square'
-          src={cdInfo?.coverUrl}
-          alt='CD 앨범 이미지'
-        />
-
+      <article className='flex pl-10 flex-1 gap-14 items-center h-full'>
         {/* 음량 */}
         <div className='flex gap-2 justify-center items-center'>
           {cdReady.isMuted ? (

--- a/src/pages/cd/components/player/MiddleGroup.tsx
+++ b/src/pages/cd/components/player/MiddleGroup.tsx
@@ -11,7 +11,7 @@ interface MiddleProps {
 const MiddleGroup = React.memo(
   ({ handleOnOffCd, cdStateChangeEvent, cdReady }: MiddleProps) => {
     return (
-      <article className='flex flex-col items-center  pl-11 '>
+      <article className='flex flex-col items-center '>
         <button onClick={() => handleOnOffCd(cdStateChangeEvent)}>
           <img
             className='w-11 h-11'

--- a/src/pages/cd/components/player/RightGroup.tsx
+++ b/src/pages/cd/components/player/RightGroup.tsx
@@ -25,7 +25,7 @@ const RightGroup = React.memo(
           />
         </button>
 
-        <button onClick={() => navigate('/')}>
+        <button onClick={() => navigate('/')} className="hidden md:block">
           <img
             className='w-8'
             src={homeIcon}

--- a/src/pages/cd/components/template/CdTemplate.tsx
+++ b/src/pages/cd/components/template/CdTemplate.tsx
@@ -39,9 +39,11 @@ const CdTemplate = React.memo(() => {
 
   return (
     <div
-      // pl-12 pr-5 py-15
-      className='w-[32%]  text-white rounded-3xl border-2   border-[#FCF7FD]
-     bg-[#3E507D1A] backdrop-blur-lg shadow-box h-full flex justify-center items-center  relative  '>
+      className='order-2 md:order-1
+        w-full text-white rounded-3xl border-2 border-[#FCF7FD]
+        bg-[#3E507D1A] backdrop-blur-lg shadow-box
+        flex justify-center items-center relative
+        h-[300px] md:h-full '>
       {isEdit ? (
         <EditTemplate
           questions={questions}

--- a/src/pages/cdrack/components/CdRack.tsx
+++ b/src/pages/cdrack/components/CdRack.tsx
@@ -2,6 +2,7 @@ import { Canvas } from '@react-three/fiber';
 import * as THREE from 'three';
 import useCdModel from '../hooks/useCdModel';
 import CdRackScene from './CdRackScene';
+import { cdSettings } from '../constants/cdSettings';
 
 export default function CdRack({ items, isModalOpen }: CdRackProps) {
   const { caseGeom, cdGeom, coverGeom, caseAxisIndex } = useCdModel();
@@ -16,7 +17,18 @@ export default function CdRack({ items, isModalOpen }: CdRackProps) {
         outputColorSpace: THREE.SRGBColorSpace,
       }}
       camera={{ fov: 15, near: 0.1, far: 40 }}
-      className='w-full h-full'>
+      className='w-full h-full'
+      onCreated={({ camera }) => {
+        const pitch = THREE.MathUtils.degToRad(cdSettings.CAM_PITCH);
+        camera.position.set(
+          0,
+          Math.cos(pitch) * cdSettings.CAM_RADIUS * 0.004,
+          Math.sin(pitch) * cdSettings.CAM_RADIUS,
+        );
+        camera.up.set(0, 0, 1);
+        camera.lookAt(0, 0, 0);
+      }}
+      >
       <CdRackScene
         items={items}
         caseGeom={caseGeom}

--- a/src/pages/cdrack/components/CdRackScene.tsx
+++ b/src/pages/cdrack/components/CdRackScene.tsx
@@ -7,18 +7,7 @@ import { cdSettings } from '../constants/cdSettings';
 import CdWheel from './CdWheel';
 
 export default function CdRackScene(props: CdWheelProps) {
-  const { camera, gl, scene } = useThree();
-
-  useEffect(() => {
-    const pitch = THREE.MathUtils.degToRad(cdSettings.CAM_PITCH);
-    camera.position.set(
-      0,
-      Math.cos(pitch) * cdSettings.CAM_RADIUS * 0.004,
-      Math.sin(pitch) * cdSettings.CAM_RADIUS,
-    );
-    camera.up.set(0, 0, 1);
-    camera.lookAt(0, 0, 0);
-  }, [camera]);
+  const { gl, scene } = useThree();
 
   useEffect(() => {
     const pmrem = new THREE.PMREMGenerator(gl);

--- a/src/pages/cdrack/components/SlidingTitle.tsx
+++ b/src/pages/cdrack/components/SlidingTitle.tsx
@@ -43,7 +43,7 @@ export default function SlidingTitle({
       >
         <span
           ref={textRef}
-          className="px-4 font-bold text-[#142b4b] text-sm xl:text-lg 2xl:text-xl"
+          className="font-bold text-[#142b4b] text-sm xl:text-lg 2xl:text-xl"
         >
           {text}
         </span>


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/cd-95` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- CD 페이지 반응형 추가 및 스타일링 수정
- CD Rack 페이지 오류 해결

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `CdPage.tsx`
  - Cd 모바일 반응형 추가 (가로 -> 세로)
  - Cd에 앨범자켓 이미지 클리핑마스크 효과 추가 ( 기존 player에 있던 앨범커버 이동)

- [ ] `CdRack.tsx` & `CdRackScene.tsx`
  - 기존에 뒤로 가기로 이동 시, 카메라 위치가 세팅되기 전 렌더링 되어 깜빡이는 문제 발생
  - `useLayoutEffect` 으로 수정 후, 해결
  - 하지만 카메라는 항상 고정된 시점이기에 `Canvas` 에서 `onCreated` 로 초기에 한 번만 설정 해주는 것이 더 좋다고 판단

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
<img width="1446" height="744" alt="스크린샷 2025-09-15 오후 2 38 45" src="https://github.com/user-attachments/assets/237a624f-08eb-4be8-89c9-e8239300bc7c" />

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#95 