### PR TITLE
[fix/cd-131] 🚨 Fix: cd payload 타입 매핑 및 불필요한 타입 제거 후 요청

### DIFF
--- a/src/pages/cdrack/hooks/useCdRackData.ts
+++ b/src/pages/cdrack/hooks/useCdRackData.ts
@@ -5,6 +5,7 @@ import {
   getCdRack,
 } from '../../../apis/cd';
 import { useToastStore } from '../../../store/useToastStore';
+import { mapToPostCDInfo } from '../../../utils/cdMapper';
 
 export default function useCdRackData(
   targetUserId: number | null,
@@ -82,31 +83,30 @@ export default function useCdRackData(
   }, [fetchPage, nextCursor, hasMore]);
 
   const addCd = useCallback(
-    async (cdData: PostCDInfo) => {
+    async (rawCd: RawCDInfo) => {
+      const payload = mapToPostCDInfo(rawCd);
+
       const tempItem: CdItem = {
         myCdId: Date.now(),
-        coverUrl: cdData.coverUrl,
-        title: cdData.title,
-        artist: cdData.artist,
-        album: cdData.album,
-        genres: cdData.genres ?? [],
-        releaseDate: cdData.releaseDate ?? '',
-        youtubeUrl: cdData.youtubeUrl ?? '',
-        duration: cdData.duration ?? 0,
+        coverUrl: payload.coverUrl,
+        title: payload.title,
+        artist: payload.artist,
+        album: payload.album,
+        genres: payload.genres ?? [],
+        releaseDate: payload.releaseDate ?? '',
+        youtubeUrl: payload.youtubeUrl ?? '',
+        duration: payload.duration ?? 0,
       };
 
       setOptimisticItems([...optimisticItems, tempItem]);
 
       try {
-        const res = await addCdToMyRack(cdData);
-        if(res){
-          setItems((prev) => [...prev, res]);
-          // window.location.reload();
+        const res = await addCdToMyRack(payload);
+        if (res?.data) {
+          setItems((prev) => [...prev, res.data]);
         }
       } catch (err) {
         console.error('🚨 CD 추가 실패 (rollback):', err);
-        // window.location.reload();
-
       }
     },
     [setOptimisticItems, optimisticItems],

--- a/src/types/cd.d.ts
+++ b/src/types/cd.d.ts
@@ -157,3 +157,16 @@ interface CdDeleteModalProps {
   onClose: () => void;
   onDelete: (ids: number[]) => void;
 }
+
+interface RawCDInfo {
+  id: number;
+  title: string;
+  artist: string;
+  album_title: string;
+  date: string;
+  duration: number;
+  genres: string[];
+  imageUrl: string;
+  type: string;
+  youtubeUrl: string;
+}

--- a/src/utils/cdMapper.ts
+++ b/src/utils/cdMapper.ts
@@ -1,0 +1,12 @@
+export function mapToPostCDInfo(raw: RawCDInfo): PostCDInfo {
+  return {
+    title: raw.title,
+    artist: raw.artist,
+    album: raw.album_title,     
+    genres: raw.genres,
+    coverUrl: raw.imageUrl,   
+    youtubeUrl: raw.youtubeUrl,
+    duration: raw.duration,
+    releaseDate: raw.date,  
+  };
+}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/cd-131` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
cd payload 타입 매핑 및 불필요한 타입 제거 후 요청

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항

- [x] RawCDInfo 타입 정의 (album_title, imageUrl, date 등 원본 필드 포함)
- [x] utils/cdMapper.ts에 mapToPostCDInfo 유틸 추가
→ 원본 RawCDInfo → 서버가 기대하는 PostCDInfo로 변환
- [x] useCdRackData.ts의 addCd에서 mapToPostCDInfo 적용
→ 서버에 불필요한 필드(id, type) 제외하고 올바른 필드명(coverUrl, album, releaseDate)으로 전송


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#131 