### PR TITLE
[fix/cdrack-134] 🚨 Fix: 서버 응답 시 임시 아이템 교체

### DIFF
--- a/src/pages/cdrack/hooks/useCdRackData.ts
+++ b/src/pages/cdrack/hooks/useCdRackData.ts
@@ -86,8 +86,9 @@ export default function useCdRackData(
     async (rawCd: RawCDInfo) => {
       const payload = mapToPostCDInfo(rawCd);
 
+      const tempId = Date.now();
       const tempItem: CdItem = {
-        myCdId: Date.now(),
+        myCdId: tempId,
         coverUrl: payload.coverUrl,
         title: payload.title,
         artist: payload.artist,
@@ -103,10 +104,16 @@ export default function useCdRackData(
       try {
         const res = await addCdToMyRack(payload);
         if (res?.data) {
+          setOptimisticItems((prev) =>
+            prev.map((item) => (item.myCdId === tempId ? res.data : item)),
+          );
           setItems((prev) => [...prev, res.data]);
         }
       } catch (err) {
         console.error('🚨 CD 추가 실패 (rollback):', err);
+        setOptimisticItems((prev) =>
+          prev.filter((item) => item.myCdId !== tempId),
+        );
       }
     },
     [setOptimisticItems, optimisticItems],


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/cdrack-134` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
서버 응답 시 임시 아이템 교체 (낙관적 업데이트 부분)

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항

- [x] addCd 로직 개선
  - 낙관적 아이템 추가 시 Date.now() 기반 임시 ID를 부여

- [x] 서버 응답이 오면 임시 아이템을 서버에서 반환한 아이템으로 교체

- [x] 실패 시 임시 아이템 롤백
  - optimisticItems와 items 상태를 함께 관리하여 UI 즉시 반영 + 서버 데이터 동기화 보장


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#134 