### PR TITLE
[fix/cd-137] 🚨 Fix: CD 추가 중복 api 호출 제거

### DIFF
--- a/src/components/search-modal/SearchResult.tsx
+++ b/src/components/search-modal/SearchResult.tsx
@@ -104,11 +104,7 @@ export const SearchResult = ({
           return;
         }
 
-        // // console.log('request body', cdData);
-        const result = await addCdToMyRack(cdData);
-        // // console.log('response body', result);
-
-        onSelect({ ...item, youtubeUrl, duration, id: result.myCdId });
+        onSelect({ ...item, youtubeUrl, duration });
         showToast('랙에 cd가 추가되었어요!', 'success');
         onClose();
       }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/cd-137` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
CD 추가 중복 api 호출 제거

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항

- SearchResult 컴포넌트에서 CD 추가 API 호출 제거
- 이제 SearchResult는 선택된 CD 데이터만 상위(onSelect)로 전달
- 실제 API 호출(addCdToMyRack)은 부모 훅(useCdRackData.addCd)에서만 수행

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- PR에 대해 어떻게 생각하시나요?

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#137 