### PR TITLE
[Fix/cd-140] 🚨 Fix: CD 추가 로직 중복 호출 제거 및 optimistic 업데이트 개선

### DIFF
--- a/src/components/search-modal/SearchResult.tsx
+++ b/src/components/search-modal/SearchResult.tsx
@@ -2,7 +2,7 @@ import { bookAPI } from '@/apis/book';
 import addIcon from '@/assets/add-icon.svg';
 import { SEARCH_THEME } from '@/constants/searchTheme';
 import { toKoreanDate } from '@utils/dateFormat';
-import { addCdToMyRack, getYoutubeUrl, upgradeCdLevel } from '@apis/cd';
+import { upgradeCdLevel } from '@apis/cd';
 import { useUserStore } from '@/store/useUserStore';
 import { useToastStore } from '@/store/useToastStore';
 import AlertModal from '@components/AlertModal';
@@ -73,39 +73,7 @@ export const SearchResult = ({
           genres: response.genreNames,
         });
       } else if (type === 'CD') {
-        // CD 추가 요청 로직
-
-        const { youtubeUrl, duration } = await getYoutubeUrl(
-          item.title,
-          item.artist,
-        );
-
-        const cdData: PostCDInfo = {
-          title: item.title,
-          artist: item.artist,
-          album: item.album_title,
-          genres: item.genres,
-          coverUrl: item.imageUrl,
-          youtubeUrl: youtubeUrl,
-          duration: duration,
-          releaseDate: item.date,
-        };
-
-        // CD를 추가할 수 없는 경우
-        if (
-          !youtubeUrl ||
-          !duration ||
-          !cdData.title ||
-          !cdData.artist ||
-          !cdData.album ||
-          !cdData.releaseDate
-        ) {
-          setIsAlertModalOpen(true);
-          return;
-        }
-
-        onSelect({ ...item, youtubeUrl, duration });
-        showToast('랙에 cd가 추가되었어요!', 'success');
+        onSelect(item);
         onClose();
       }
     } catch (error) {

--- a/src/pages/cdrack/CdRackPage.tsx
+++ b/src/pages/cdrack/CdRackPage.tsx
@@ -11,6 +11,7 @@ import CdDockMenu from './components/CdDockMenu';
 import CdHoverLabel from './components/CdHoverLabel';
 import CdRack from './components/CdRack';
 import useCdRackData from './hooks/useCdRackData';
+import { mapToRawCd } from '../../utils/cdMapper';
 
 
 export default function CdRackPage() {
@@ -97,7 +98,7 @@ export default function CdRackPage() {
             title='CD 랙에 담을 음악 찾기'
             onClose={handleCloseSettings}
             type='CD'
-            onSelect={(cdItem) => addCd(cdItem)}
+            onSelect={(cdItem) => addCd(mapToRawCd(cdItem))}
           />
         )}
         {activeSettings === 'delete' && (

--- a/src/pages/cdrack/hooks/useCdRackData.ts
+++ b/src/pages/cdrack/hooks/useCdRackData.ts
@@ -139,7 +139,7 @@ export default function useCdRackData(
         fetchPage(null);
       }
     },
-    [setOptimisticItems, optimisticItems, fetchPage, showToast],
+    [setOptimisticItems, fetchPage, showToast],
   );
 
   const isLoading = initialLoading || isFetchingMore;

--- a/src/pages/cdrack/hooks/useCdRackData.ts
+++ b/src/pages/cdrack/hooks/useCdRackData.ts
@@ -99,7 +99,7 @@ export default function useCdRackData(
         duration: payload.duration ?? 0,
       };
 
-      setOptimisticItems([...optimisticItems, tempItem]);
+      setOptimisticItems((prev) => [...prev, tempItem]);
 
       try {
         const res = await addCdToMyRack(payload);
@@ -116,13 +116,13 @@ export default function useCdRackData(
         );
       }
     },
-    [setOptimisticItems, optimisticItems],
+    [setOptimisticItems],
   );
 
   const deleteCd = useCallback(
     async (myCdIds: number[]) => {
-      setOptimisticItems(
-        optimisticItems.filter((cd) => !myCdIds.includes(cd.myCdId)),
+      setOptimisticItems((prev) =>
+        prev.filter((cd) => !myCdIds.includes(cd.myCdId)),
       );
 
       try {

--- a/src/utils/cdMapper.ts
+++ b/src/utils/cdMapper.ts
@@ -10,3 +10,18 @@ export function mapToPostCDInfo(raw: RawCDInfo): PostCDInfo {
     releaseDate: raw.date,  
   };
 }
+
+export function mapToRawCd(item: SearchItemType): RawCDInfo {
+  return {
+    id: Number(item.id),
+    title: item.title,
+    artist: item.artist,
+    album_title: item.album_title,
+    genres: item.genres,
+    imageUrl: item.imageUrl,
+    date: item.date,
+    youtubeUrl: item.youtubeUrl ?? '',
+    duration: item.duration ?? 0,
+    type: 'CD',
+  };
+}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Fix/cd-140` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
CD 추가 로직 중복 호출 제거 및 optimistic 업데이트 개선

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항

- [ ] 중복 호출 제거
- SearchResult에서 CD 추가 API 호출 로직 제거 → 상위(useSearchActions/useCdRackData)에서만 API 요청 처리
- SearchModal에서 onAdd와 onSelect 역할을 정리하여 이중 호출 방지

- [ ] optimistic 업데이트 개선
- setOptimisticItems([...optimisticItems, temp]) → setOptimisticItems(prev => [...prev, temp])로 수정
- deleteCd도 동일하게 함수형 업데이트 적용
- 서버 응답 시 tempItem을 실제 응답 데이터로 교체 → 추가 직후 UI 즉시 반영 가능

- [ ] 타입 변환 구조 정리
- SearchItemType → RawCDInfo → PostCDInfo 2단계 매핑 체계 확립
- mapToRawCd 유틸 추가 (SearchItemType을 내부 로직에서 쓰는 RawCDInfo로 변환)
- mapToPostCDInfo는 RawCDInfo → PostCDInfo 변환 전담
- addCd 호출 시 타입 불일치(id: string → number) 문제 해결
- 

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- PR에 대해 어떻게 생각하시나요?

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#140 