### PR TITLE
[HotFix] 🚨 Fix: cd 추가시 중복 추가 로직 수정

### DIFF
--- a/src/pages/cdrack/CdRackPage.tsx
+++ b/src/pages/cdrack/CdRackPage.tsx
@@ -11,29 +11,19 @@ import CdDockMenu from './components/CdDockMenu';
 import CdHoverLabel from './components/CdHoverLabel';
 import CdRack from './components/CdRack';
 import useCdRackData from './hooks/useCdRackData';
-import { mapToRawCd } from '../../utils/cdMapper';
-
 
 export default function CdRackPage() {
   const { userId: myUserId } = useUserStore().user;
   const { userId } = useParams();
   const targetUserId = Number(userId);
-  const {
-    items,
-    initialLoading,
-    isFetchingMore,
-    hasMore,
-    loadMore,
-    addCd,
-    deleteCd,
-  } = useCdRackData(targetUserId, 14);
+  const { items, initialLoading, isFetchingMore, hasMore, loadMore, deleteCd } =
+    useCdRackData(targetUserId, 14);
   const [activeSettings, setActiveSettings] = useState<'add' | 'delete' | null>(
     null,
   );
   const [resetDockMenuState, setResetDockMenuState] = useState(false);
   const phase = useCdStore((set) => set.phase);
   const isModalOpen = activeSettings === 'add' || activeSettings === 'delete';
-  
 
   useEffect(() => {
     if (phase > items.length - 3 && hasMore && !isFetchingMore) {
@@ -98,7 +88,7 @@ export default function CdRackPage() {
             title='CD 랙에 담을 음악 찾기'
             onClose={handleCloseSettings}
             type='CD'
-            onSelect={(cdItem) => addCd(mapToRawCd(cdItem))}
+            onSelect={() => {}}
           />
         )}
         {activeSettings === 'delete' && (


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`HotFix` -> `main`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
cd 추가 API를 호출하는 로직이 두 군데 중복되어 있었음

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] src/pages/cdrack/CdRackPage.tsx: addCd(mapToRawCd(...)) 호출 제거, 모달만 열도록 변경
- [x] src/components/search-modal/hooks/useSearchActions.ts: CD 추가 로직을 공용 매퍼 기반으로 단순화 및 일원화
- [x] 불필요 import/주석 정리, 타입 오류 점검

## 🔧 상세 변경
- CdRackPage.tsx
  - SearchModal의 onSelect에서 랙 훅의 addCd 호출 제거
  - 불필요한 mapToRawCd import 삭제
- useSearchActions.ts
  - getYoutubeUrl → mapToRawCd → mapToPostCDInfo → 검증 → addCdToMyRack 일관 흐름으로 단일화
  - 응답의 myCdId가 result.myCdId 또는 result.data?.myCdId인 경우 모두 처리