### PR TITLE
[performance/preview-160] ⚡️ Performance : 가상스크롤 + 프리패칭 도입

### DIFF
--- a/src/pages/main/components/HiveRoomModel.tsx
+++ b/src/pages/main/components/HiveRoomModel.tsx
@@ -1,45 +1,31 @@
+import { RoomModelCache } from '@pages/main/utils/RoomModelCache';
 import { Center, useGLTF } from '@react-three/drei';
 import { useEffect, useMemo } from 'react';
-import * as THREE from 'three';
 
-export default function HiveRoomModel({ room, position, onModelLoaded }: HiveRoomModelProps) {
+export default function HiveRoomModel({
+  room,
+  onModelLoaded,
+}: HiveRoomModelProps) {
   const { scene: originalScene } = useGLTF(room.modelPath) as GLTFResult;
 
   const scene = useMemo(() => {
-    const clonedScene = originalScene.clone();
-
-    clonedScene.traverse((object: THREE.Object3D) => {
-      if (object instanceof THREE.Mesh) {
-        object.material = (object.material as THREE.Material).clone();
-        object.geometry = object.geometry.clone();
-
-        object.castShadow = true;
-        object.receiveShadow = true;
-      }
-    });
-    return clonedScene;
-  }, [originalScene]);
+    return RoomModelCache.getInstance(room.modelPath, originalScene);
+  }, [originalScene, room.modelPath]);
 
   const roomScale = 0.5;
 
   useEffect(() => {
     if (!scene) return;
-
-    scene.position.set(...position);
-    const box = new THREE.Box3().setFromObject(scene);
-    const center = new THREE.Vector3();
-    box.getCenter(center);
-
     onModelLoaded(room.roomId);
-  }, [scene, room.roomId, position, onModelLoaded]);
+  }, [scene, room.roomId, onModelLoaded]);
 
   return (
-      <Center>
-        <primitive
-          object={scene}
-          scale={roomScale}
-          rotation={[0, -Math.PI / 4, 0]}
-        />
-      </Center>
+    <Center>
+      <primitive
+        object={scene}
+        scale={roomScale}
+        rotation={[0, -Math.PI / 4, 0]}
+      />
+    </Center>
   );
 }

--- a/src/pages/main/components/HiveRooms.tsx
+++ b/src/pages/main/components/HiveRooms.tsx
@@ -1,13 +1,14 @@
+import HiveRoomsScene from '@pages/main/components/HiveRoomsScene';
+import useHiveInteractions from '@pages/main/hooks/useHiveInteractions';
+import useHiveLoading from '@pages/main/hooks/useHiveLoading';
 import { OrbitControls } from '@react-three/drei';
-import { Canvas, ThreeEvent } from '@react-three/fiber';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
 import { useNavigate } from 'react-router-dom';
 import * as THREE from 'three';
 import Loading from '../../../components/Loading';
 import { RoomLighting } from '../../../components/room-models/RoomLighting';
 import useHexagonGrid from '../hooks/useHexagonGrid';
 import useRooms from '../hooks/useRooms';
-import HiveRoomModel from './HiveRoomModel';
 
 export default function HiveRooms({
   myUserId,
@@ -15,63 +16,25 @@ export default function HiveRooms({
 }: HiveRoomsProps) {
   const { rooms } = useRooms(myUserId);
   const positionedRooms = useHexagonGrid(rooms, 0, 0);
-  const [isLoading, setIsLoading] = useState(true);
-  const [loadedRooms, setLoadedRooms] = useState(new Set());
-  const [hoveredRoom, setHoveredRoom] = useState<number | null>(null);
   const navigate = useNavigate();
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const startPos = useRef<{ x: number; y: number } | null>(null);
-  const tapThreshold = 8;
+  const {
+    hoveredIndex,
+    handlePointerDown,
+    handlePointerUp,
+    handlePointerOver,
+    handlePointerOut,
+  } = useHiveInteractions(rooms, navigate);
 
-  const handlePointerDown = (e: ThreeEvent<PointerEvent>) => {
-    startPos.current = { x: e.clientX, y: e.clientY };
-  };
-
-  const handlePointerUp = (e: ThreeEvent<PointerEvent>, roomIndex: number) => {
-    if (!startPos.current) return;
-    const dx = e.clientX - startPos.current.x;
-    const dy = e.clientY - startPos.current.y;
-    const distance = Math.sqrt(dx * dx + dy * dy);
-
-    if (distance < tapThreshold) {
-      const room = rooms[roomIndex];
-      if (room?.userId) {
-        navigate(`/room/${room.userId}`);
-      }
-    }
-    startPos.current = null;
-  };
-
-  const handlePointerOver = useCallback((index: number) => {
-    setHoveredRoom(index);
-  }, []);
-
-  const handlePointerOut = useCallback(() => {
-    setHoveredRoom(null);
-  }, []);
-
-  const handleModelLoaded = useCallback((roomId: string) => {
-    setLoadedRooms((prev) => {
-      if (prev.has(roomId)) return prev;
-      const newSet = new Set(prev);
-      newSet.add(roomId);
-      return newSet;
-    });
-  }, []);
-
-  useEffect(() => {
-    if (loadedRooms.size === rooms.length && rooms.length > 0) {
-      setIsLoading(false);
-      if (onLoadingComplete) onLoadingComplete();
-    }
-  }, [loadedRooms, rooms.length, onLoadingComplete]);
+  const { isLoading, handleModelLoaded } = useHiveLoading(
+    rooms.length,
+    onLoadingComplete,
+  );
 
   return (
     <div className='w-full h-screen relative'>
       {isLoading && <Loading />}
       <Canvas
-        ref={canvasRef}
         camera={{ position: [0, 4, 10], fov: 25 }}
         shadows>
         <RoomLighting />
@@ -82,22 +45,14 @@ export default function HiveRooms({
           shadow-mapSize-width={1024}
           shadow-mapSize-height={1024}
         />
-        {positionedRooms.map(({ room, position }, index: number) => (
-          <group
-            key={index}
-            position={position}
-            onPointerDown={handlePointerDown}
-            onPointerUp={(e) => handlePointerUp(e, index)}
-            onPointerOver={() => handlePointerOver(index)}
-            onPointerOut={handlePointerOut}>
-            
-            <HiveRoomModel
-              room={room}
-              position={position}
-              onModelLoaded={handleModelLoaded}
-            />
-          </group>
-        ))}
+        <HiveRoomsScene
+          positionedRooms={positionedRooms}
+          onPointerDown={handlePointerDown}
+          onPointerUp={handlePointerUp}
+          onPointerOver={handlePointerOver}
+          onPointerOut={handlePointerOut}
+          onModelLoaded={handleModelLoaded}
+        />
         <OrbitControls
           enableRotate={false}
           enableZoom={true}
@@ -111,7 +66,7 @@ export default function HiveRooms({
           }}
         />
       </Canvas>
-      {hoveredRoom !== null && (
+      {hoveredIndex !== null && (
         <div
           className='absolute bottom-22 left-1/2 transform -translate-x-1/2 font-medium z-30'
           style={{
@@ -123,10 +78,10 @@ export default function HiveRooms({
             fontSize: '14px',
             pointerEvents: 'none',
             whiteSpace: 'nowrap',
-            opacity: hoveredRoom !== null ? 1 : 0,
+            opacity: hoveredIndex !== null ? 1 : 0,
             transition: 'opacity 0.2s ease-in-out',
           }}>
-          {`✊🏻 똑똑! ${rooms[hoveredRoom]?.nickname}의 방에 들어가실래요?`}
+          {`✊🏻 똑똑! ${rooms[hoveredIndex]?.nickname}의 방에 들어가실래요?`}
         </div>
       )}
     </div>

--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -1,0 +1,100 @@
+import { useGLTF } from '@react-three/drei';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useEffect, useRef, useState } from 'react';
+
+import { HiveSpatialIndex } from '@pages/main/utils/hiveSpatialIndex';
+import HiveRoomModel from './HiveRoomModel';
+
+interface HiveRoomsSceneProps {
+  positionedRooms: PositionedRoom[];
+  onPointerDown: (e) => void;
+  onPointerUp: (e, index: number) => void;
+  onPointerOver: (index: number) => void;
+  onPointerOut: () => void;
+  onModelLoaded: (roomId: string) => void;
+}
+
+const VISIBLE_RADIUS = 18; // 렌더링 반경
+const PREFETCH_RADIUS_INNER = 18; // 프리패치 시작
+const PREFETCH_RADIUS_OUTER = 24; // 프리패치 끝
+
+export default function HiveRoomsScene({
+  positionedRooms,
+  onPointerDown,
+  onPointerUp,
+  onPointerOver,
+  onPointerOut,
+  onModelLoaded,
+}: HiveRoomsSceneProps) {
+  const { camera } = useThree();
+
+  const indexRef = useRef<HiveSpatialIndex | null>(null);
+  const [visibleIndices, setVisibleIndices] = useState<Set<number>>(new Set());
+  const [prefetchPaths, setPrefetchPaths] = useState<string[]>([]);
+
+  useEffect(() => {
+    indexRef.current = new HiveSpatialIndex(positionedRooms);
+  }, [positionedRooms]);
+
+  useFrame(() => {
+    const index = indexRef.current;
+    if (!index) return;
+
+    const camX = camera.position.x;
+    const camZ = camera.position.z;
+
+    const visible = index.getVisible(camX, camZ, VISIBLE_RADIUS);
+    const prefetch = index.getPrefetchTargets(
+      camX,
+      camZ,
+      PREFETCH_RADIUS_INNER,
+      PREFETCH_RADIUS_OUTER,
+    );
+
+    const nextVisible = new Set(visible.map((v) => v.index));
+    setVisibleIndices((prev) => {
+      if (prev.size === nextVisible.size) {
+        let same = true;
+        prev.forEach((v) => {
+          if (!nextVisible.has(v)) same = false;
+        });
+        if (same) return prev;
+      }
+      return nextVisible;
+    });
+
+    setPrefetchPaths(prefetch.map((v) => v.modelPath));
+  });
+
+  useEffect(() => {
+    const uniquePaths = Array.from(new Set(prefetchPaths));
+    uniquePaths.forEach((path) => {
+      if (path) {
+        useGLTF.preload(path);
+      }
+    });
+  }, [prefetchPaths]);
+
+  return (
+    <>
+      {positionedRooms
+        .filter(
+          ({ index }) => visibleIndices.size === 0 || visibleIndices.has(index),
+        )
+        .map(({ room, position, index }) => (
+          <group
+            key={room.roomId}
+            position={position}
+            onPointerDown={onPointerDown}
+            onPointerUp={(e) => onPointerUp(e, index)}
+            onPointerOver={() => onPointerOver(index)}
+            onPointerOut={onPointerOut}>
+            <HiveRoomModel
+              room={room}
+              onModelLoaded={onModelLoaded}
+            />
+          </group>
+        ))}
+    </>
+  );
+}

--- a/src/pages/main/hooks/useHexagonGrid.ts
+++ b/src/pages/main/hooks/useHexagonGrid.ts
@@ -38,7 +38,11 @@ function expandRing(
     const baseIndex = previousRing[(directionIndex + i) % previousRing.length];
     const basePos = result[baseIndex].position;
     const [dx, dy, dz] = dir;
-    const newPos: Position = [basePos[0] + dx, basePos[1] + dy, basePos[2] + dz];
+    const newPos: Position = [
+      basePos[0] + dx,
+      basePos[1] + dy,
+      basePos[2] + dz,
+    ];
     const posKey = `${newPos[0]},${newPos[1]},${newPos[2]}`;
 
     if (!visited.has(posKey) && newPos[0] + newPos[1] + newPos[2] === 0) {
@@ -50,11 +54,19 @@ function expandRing(
   return { roomIndex, placedInRing };
 }
 
-export default function useHexagonGrid(rooms, centerX = 0, centerY = 0) {
+export default function useHexagonGrid(
+  rooms: Room[],
+  centerX = 0,
+  centerY = 0,
+) {
   const positions = useMemo(() => {
     const roomCount = rooms.length;
     if (!roomCount)
-      return rooms.map((room) => ({ room, position: [centerX, centerY, 0] }));
+      return rooms.map((room, index) => ({
+        room,
+        position: [centerX, centerY, 0] as [number, number, number],
+        index,
+      }));
 
     const result: RoomPosition[] = [];
     const visited = new Set<string>();
@@ -126,11 +138,11 @@ export default function useHexagonGrid(rooms, centerX = 0, centerY = 0) {
     const width = roomWidth;
     const height = roomHeight * 1.33;
 
-    const finalRooms = result.map(({ position: [q, r], room }) => {
+    const finalRooms = result.map(({ position: [q, r], room }, idx) => {
       const x = centerX + width * (q + r / 2);
       const y = centerY - height * (2.98 / 4.2) * r;
       const z = r * 0.7;
-      return { room, position: [x, y, z] };
+      return { room, position: [x, y, z] as [number, number, number], index: idx };
     });
 
     return finalRooms;

--- a/src/pages/main/hooks/useHiveInteractions.ts
+++ b/src/pages/main/hooks/useHiveInteractions.ts
@@ -1,0 +1,49 @@
+import { useCallback, useRef, useState } from 'react';
+import { NavigateFunction } from 'react-router-dom';
+
+export default function useHiveInteractions(
+  rooms: Room[],
+  navigate: NavigateFunction,
+) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const startPos = useRef<{ x: number; y: number } | null>(null);
+  const tapThreshold = 8;
+
+  const handlePointerDown = useCallback((e) => {
+    startPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (e, roomIndex: number) => {
+      if (!startPos.current) return;
+      const dx = e.clientX - startPos.current.x;
+      const dy = e.clientY - startPos.current.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+
+      if (distance < tapThreshold) {
+        const room = rooms[roomIndex];
+        if (room?.userId) {
+          navigate(`/room/${room.userId}`);
+        }
+      }
+      startPos.current = null;
+    },
+    [navigate, rooms],
+  );
+
+  const handlePointerOver = useCallback((index: number) => {
+    setHoveredIndex(index);
+  }, []);
+
+  const handlePointerOut = useCallback(() => {
+    setHoveredIndex(null);
+  }, []);
+
+  return {
+    hoveredIndex,
+    handlePointerDown,
+    handlePointerUp,
+    handlePointerOver,
+    handlePointerOut,
+  };
+}

--- a/src/pages/main/hooks/useHiveLoading.ts
+++ b/src/pages/main/hooks/useHiveLoading.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from "react";
+
+export default function useHiveLoading(totalRooms: number, onLoadingComplete?: () => void) {
+  const [loadedRooms, setLoadedRooms] = useState<Set<string>>(new Set());
+  const [isLoading, setIsLoading] = useState(true);
+
+  const handleModelLoaded = useCallback((roomId: string) => {
+    setLoadedRooms((prev) => {
+      if (prev.has(roomId)) return prev;
+      const next = new Set(prev);
+      next.add(roomId);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (totalRooms > 0 && loadedRooms.size >= totalRooms) {
+      setIsLoading(false);
+      onLoadingComplete?.();
+    }
+  }, [loadedRooms, totalRooms, onLoadingComplete]);
+
+  return { isLoading, handleModelLoaded };
+}

--- a/src/pages/main/utils/hiveSpatialIndex.ts
+++ b/src/pages/main/utils/hiveSpatialIndex.ts
@@ -1,0 +1,34 @@
+export class HiveSpatialIndex {
+  private items: {
+    index: number;
+    x: number;
+    z: number;
+    modelPath: string;
+  }[] = [];
+
+  constructor(positionedRooms: PositionedRoom[]) {
+    this.items = positionedRooms.map(({ index, position, room }) => ({
+      index,
+      x: position[0],
+      z: position[2],
+      modelPath: room.modelPath,
+    }));
+  }
+
+  getVisible(cameraX: number, cameraZ: number, radius: number) {
+    return this.items.filter((item) => {
+      const dx = item.x - cameraX;
+      const dz = item.z - cameraZ;
+      return Math.hypot(dx, dz) <= radius;
+    });
+  }
+
+  getPrefetchTargets(cameraX: number, cameraZ: number, inner: number, outer: number) {
+    return this.items.filter((item) => {
+      const dx = item.x - cameraX;
+      const dz = item.z - cameraZ;
+      const dist = Math.hypot(dx, dz);
+      return dist > inner && dist <= outer;
+    });
+  }
+}

--- a/src/pages/main/utils/roomModelCache.ts
+++ b/src/pages/main/utils/roomModelCache.ts
@@ -1,0 +1,26 @@
+
+import * as THREE from 'three';
+
+export class RoomModelCache {
+  private static baseScenes = new Map<string, THREE.Object3D>();
+
+  static getInstance(modelPath: string, originalScene: THREE.Object3D) {
+    let base = this.baseScenes.get(modelPath);
+
+    if (!base) {
+      base = originalScene.clone(true);
+
+      base.traverse((obj: THREE.Object3D) => {
+        const mesh = obj as THREE.Mesh;
+        if (mesh.isMesh) {
+          mesh.castShadow = true;
+          mesh.receiveShadow = true;
+        }
+      });
+
+      this.baseScenes.set(modelPath, base);
+    }
+
+    return base.clone();
+  }
+}

--- a/src/types/room.d.ts
+++ b/src/types/room.d.ts
@@ -50,11 +50,16 @@ interface Room {
 }
 interface HiveRoomModelProps {
   room: Room;
-  position: [number, number, number];
   onModelLoaded: (roomId: string) => void;
 }
 
 interface HiveRoomsProps {
   myUserId: number;
   onLoadingComplete?: () => void;
+}
+
+interface PositionedRoom {
+  room: Room;
+  position: [number, number, number];
+  index: number; 
 }


### PR DESCRIPTION

## ✨ 반영 브랜치
`performance/hive-preview-virtual-scroll` -> `dev`

## 📝 설명
RoomE Hive View 프리뷰 기능 성능 최적화를 위해 3D 가상 스크롤 + 프리페칭 로직 적용 및 GLTF 모델 캐싱 레이어를 도입하여 FPS 개선 및 초기 로딩 최적화 작업을 진행

## ✅ 변경 사항
- [x] HiveRoomsScene 컴포넌트 분리 및 비즈니스 로직 분리
- [x] 카메라 기준 거리 기반 렌더링 필터링(3D 가상 스크롤) 적용
- [x] GLTF 모델 프리페칭 적용 (`useGLTF.preload`)
- [x] RoomModelCache(Map) 기반 모델 캐싱 및 재사용 처리
- [x] 기존 position 처리 로직을 `<group>` 단위로 이동 (정석적인 R3F 배치 방식)
- [x] HiveSpatialIndex 클래스 추가 (공간 인덱싱)
- [x] useHiveInteractions / useHiveLoading 훅 추가 (컴포넌트 역할 분리)
- [x] HiveRoomModel 내부 처리 최소화 (scene.position 제거 및 clone 최적화)
- [x] PositionedRoom 타입 조정 및 튜플 타입 보장


## 📢 이슈 정보
#160
