### PR TITLE
[fix/prefetch-171] 🚨 Fix: 좌표계산 로직 수정

### DIFF
--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -41,15 +41,13 @@ export default function HiveRoomsScene({
     if (!index) return;
 
     const camX = camera.position.x;
-    const camZ = camera.position.z;
 
-    const visible = index.getVisible(camX, camZ, VISIBLE_RADIUS);
-    const prefetch = index.getPrefetchTargets(
-      camX,
-      camZ,
-      PREFETCH_RADIUS_INNER,
-      PREFETCH_RADIUS_OUTER,
-    );
+  const visible = index.getVisibleByX(camX, VISIBLE_RADIUS);
+  const prefetch = index.getPrefetchTargetsByX(
+    camX,
+    PREFETCH_RADIUS_INNER,
+    PREFETCH_RADIUS_OUTER,
+  );
 
     const nextVisible = new Set(visible.map((v) => v.index));
     setVisibleIndices((prev) => {

--- a/src/pages/main/engine/HiveSpatialIndex.ts
+++ b/src/pages/main/engine/HiveSpatialIndex.ts
@@ -6,7 +6,9 @@ export class HiveSpatialIndex {
     modelPath: string;
   }[];
 
-  constructor(positionedRooms: { room: Room; position: [number, number, number] }[]) {
+  constructor(
+    positionedRooms: { room: Room; position: [number, number, number] }[],
+  ) {
     this.items = positionedRooms.map(({ room, position }, index) => ({
       index,
       x: position[0],
@@ -15,20 +17,23 @@ export class HiveSpatialIndex {
     }));
   }
 
-  getVisible(cameraX: number, cameraZ: number, radius: number) {
+  getVisibleByX(cameraX: number, halfWidth: number) {
     return this.items.filter((item) => {
       const dx = item.x - cameraX;
-      const dz = item.z - cameraZ;
-      return Math.hypot(dx, dz) <= radius;
+      const distX = Math.abs(dx);
+      return distX <= halfWidth;
     });
   }
 
-  getPrefetchTargets(cameraX: number, cameraZ: number, inner: number, outer: number) {
+  getPrefetchTargetsByX(
+    cameraX: number,
+    innerHalfWidth: number,
+    outerHalfWidth: number,
+  ) {
     return this.items.filter((item) => {
       const dx = item.x - cameraX;
-      const dz = item.z - cameraZ;
-      const dist = Math.hypot(dx, dz);
-      return dist > inner && dist <= outer;
+      const distX = Math.abs(dx);
+      return distX > innerHalfWidth && distX <= outerHalfWidth;
     });
   }
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/prefetch-171` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
줌인/줌아웃 시 방들이 깜빡이며 사라지는 현상을 해결하기 위해,
가시성 판단 로직을 `distance 기반`에서 `camera.x 기반(가로 스크롤)`으로 변경

이를 통해 가상 스크롤 + 프리페칭은 **좌/우 이동 시에만 활성화**되고,
줌인/줌아웃 시 UI가 안정적으로 유지되도록 개선

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] 기존 `getVisible` / `getPrefetchTargets` 로직 제거
- [x] `HiveSpatialIndex`에 `getVisibleByX`, `getPrefetchTargetsByX` 추가
- [x] `HiveRoomsScene`의 가시성 판단을 `camera.position.x` 기준으로 변경
- [x] `useFrame`에서 줌 이벤트 영향 제거
- [x] 시야 밖 방 언마운트/프리패칭 타이밍 안정화


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#171
