### PR TITLE
[fix/prefetch-174] 🚨 Fix: X축 가상 스크롤 및 프리패칭 적용 + 카메라 경계 보정

### DIFF
--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -1,9 +1,10 @@
 import { useGLTF } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
 
-import HiveRoomModel from './HiveRoomModel';
 import { HiveSpatialIndex } from '@pages/main/engine/HiveSpatialIndex';
+import HiveRoomModel from './HiveRoomModel';
 
 interface HiveRoomsSceneProps {
   positionedRooms: PositionedRoom[];
@@ -40,14 +41,29 @@ export default function HiveRoomsScene({
     const index = indexRef.current;
     if (!index) return;
 
-    const camX = camera.position.x;
+    const { minX, maxX } = index.getHorizontalBounds();
+    const halfWidth = VISIBLE_RADIUS;
 
-  const visible = index.getVisibleByX(camX, VISIBLE_RADIUS);
-  const prefetch = index.getPrefetchTargetsByX(
-    camX,
-    PREFETCH_RADIUS_INNER,
-    PREFETCH_RADIUS_OUTER,
-  );
+    let camX = camera.position.x;
+
+    const minCamX = minX + halfWidth;
+    const maxCamX = maxX - halfWidth;
+
+    if (minCamX < maxCamX) {
+      camX = THREE.MathUtils.clamp(camX, minCamX, maxCamX);
+      camera.position.x = camX;
+    } else {
+      camX = (minX + maxX) / 2;
+      camera.position.x = camX;
+    }
+
+    const visible = index.getVisibleByX(camX, halfWidth);
+    
+    const prefetch = index.getPrefetchTargetsByX(
+      camX,
+      PREFETCH_RADIUS_INNER,
+      PREFETCH_RADIUS_OUTER,
+    );
 
     const nextVisible = new Set(visible.map((v) => v.index));
     setVisibleIndices((prev) => {

--- a/src/pages/main/engine/HiveSpatialIndex.ts
+++ b/src/pages/main/engine/HiveSpatialIndex.ts
@@ -6,6 +6,9 @@ export class HiveSpatialIndex {
     modelPath: string;
   }[];
 
+  private minX: number;
+  private maxX: number;
+
   constructor(
     positionedRooms: { room: Room; position: [number, number, number] }[],
   ) {
@@ -15,13 +18,17 @@ export class HiveSpatialIndex {
       z: position[2],
       modelPath: room.modelPath ?? '',
     }));
+    const xs = this.items.map((i) => i.x);
+    this.minX = Math.min(...xs);
+    this.maxX = Math.max(...xs);
   }
 
   getVisibleByX(cameraX: number, halfWidth: number) {
+    const left = cameraX - halfWidth;
+    const right = cameraX + halfWidth;
+
     return this.items.filter((item) => {
-      const dx = item.x - cameraX;
-      const distX = Math.abs(dx);
-      return distX <= halfWidth;
+      return item.x >= left && item.x <= right;
     });
   }
 
@@ -30,10 +37,20 @@ export class HiveSpatialIndex {
     innerHalfWidth: number,
     outerHalfWidth: number,
   ) {
+    const innerLeft = cameraX - innerHalfWidth;
+    const innerRight = cameraX + innerHalfWidth;
+    const outerLeft = cameraX - outerHalfWidth;
+    const outerRight = cameraX + outerHalfWidth;
+
     return this.items.filter((item) => {
-      const dx = item.x - cameraX;
-      const distX = Math.abs(dx);
-      return distX > innerHalfWidth && distX <= outerHalfWidth;
+      const x = item.x;
+      const inOuter = x >= outerLeft && x <= outerRight;
+      const inInner = x >= innerLeft && x <= innerRight;
+      return inOuter && !inInner;
     });
+  }
+  
+  getHorizontalBounds() {
+    return { minX: this.minX, maxX: this.maxX };
   }
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/prefetch-174` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
헥사곤 미리보기 화면에서 X축 이동 시 방이 사라지거나 깜빡이는 문제를 해결하기 위해
SpatialIndex 기반 가상 스크롤 & 프리패칭 로직을 도입하고,
카메라 이동 범위를 방이 존재하는 영역 내로 클램핑하여 빈 화면 노출을 방지

또한 줌 인/줌 아웃 시 visible 영역이 흔들리며 flickering 되는 현상도 제거

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `HiveSpatialIndex` 추가 (타원 기반에서 X축 단방향 로직으로 변경)
- [x] `getVisibleByX`, `getPrefetchTargetsByX` 도입
- [x] 카메라 `position.x` 범위 `minX+radius ~ maxX-radius`로 clamp 적용
- [x] 줌 이벤트가 visible 판단에 영향 주지 않도록 로직 분리
- [x] 프리패칭 구간 `inner ~ outer` 2단계로 분리
- [x] 중복 프리패치 경로 제거 및 useGLTF.preload 적용


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#174
