### PR TITLE
[fix/camera-177] 🚨 Fix: 카메라 초기 세팅 추가

### DIFF
--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -15,7 +15,7 @@ interface HiveRoomsSceneProps {
   onModelLoaded: (roomId: string) => void;
 }
 
-const VISIBLE_RADIUS = 18; // 렌더링 반경
+const VISIBLE_HALF_WIDTH = 18; // 렌더링 반경
 const PREFETCH_RADIUS_INNER = 18; // 프리패치 시작
 const PREFETCH_RADIUS_OUTER = 24; // 프리패치 끝
 
@@ -37,19 +37,29 @@ export default function HiveRoomsScene({
     indexRef.current = new HiveSpatialIndex(positionedRooms);
   }, [positionedRooms]);
 
+  useEffect(() => {
+    const index = indexRef.current;
+    if (!index) return;
+
+    const { minX, maxX } = index.getHorizontalBounds();
+    const centerX = (minX + maxX) / 2;
+
+    camera.position.x = centerX;
+  }, [positionedRooms, camera]);
+
   useFrame(() => {
     const index = indexRef.current;
     if (!index) return;
 
     const { minX, maxX } = index.getHorizontalBounds();
-    const halfWidth = VISIBLE_RADIUS;
-
+    const halfWidth = VISIBLE_HALF_WIDTH;
     let camX = camera.position.x;
 
-    const minCamX = minX + halfWidth;
-    const maxCamX = maxX - halfWidth;
+    const contentWidth = maxX - minX;
 
-    if (minCamX < maxCamX) {
+    if (contentWidth > halfWidth * 2) {
+      const minCamX = minX + halfWidth;
+      const maxCamX = maxX - halfWidth;
       camX = THREE.MathUtils.clamp(camX, minCamX, maxCamX);
       camera.position.x = camX;
     } else {
@@ -58,7 +68,6 @@ export default function HiveRoomsScene({
     }
 
     const visible = index.getVisibleByX(camX, halfWidth);
-    
     const prefetch = index.getPrefetchTargetsByX(
       camX,
       PREFETCH_RADIUS_INNER,
@@ -92,9 +101,10 @@ export default function HiveRoomsScene({
   return (
     <>
       {positionedRooms
-        .filter(
-          ({ index }) => visibleIndices.size === 0 || visibleIndices.has(index),
-        )
+        .filter(({ index }) => {
+          if (visibleIndices.size === 0) return true;
+          return visibleIndices.has(index);
+        })
         .map(({ room, position, index }) => (
           <group
             key={room.roomId}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/camera-177` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
헥사곤 미리보기 화면 진입 시 방이 보이지 않거나, 방 개수가 적을 때 빈 화면이 노출되는 문제 해결

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `HiveSpatialIndex` 기반 초기 카메라 중심 정렬 `(centerX = (minX+maxX)/2)`
- [x] `contentWidth < viewportWidth` 케이스 대응 (좁은 맵에서 중앙 고정)

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- PR에 대해 어떻게 생각하시나요?

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#177