### PR TITLE
[fix/preview-183] 🚨 Fix: 카메라 기반 가상 스크롤 + 프러스텀 필터링 + 프리패칭 시스템 도입

### DIFF
--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -1,6 +1,7 @@
 import { useGLTF } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
 
 import { HiveSpatialIndex } from '@pages/main/engine/HiveSpatialIndex';
 import HiveRoomModel from './HiveRoomModel';
@@ -14,9 +15,10 @@ interface HiveRoomsSceneProps {
   onModelLoaded: (roomId: string) => void;
 }
 
-const VISIBLE_HALF_WIDTH = 18; // 렌더링 반경
-const PREFETCH_RADIUS_INNER = 18; // 프리패치 시작
-const PREFETCH_RADIUS_OUTER = 24; // 프리패치 끝
+const ROOM_RADIUS = 2.5;
+const PREFETCH_MARGIN = 5;
+
+const BROAD_RADIUS = 40;
 
 export default function HiveRoomsScene({
   positionedRooms,
@@ -43,15 +45,46 @@ export default function HiveRoomsScene({
     if (!positionedRooms.length) return;
 
     const camX = camera.position.x;
+    const camZ = camera.position.z;
 
-    const visible = index.getVisibleByX(camX, VISIBLE_HALF_WIDTH);
-    const prefetch = index.getPrefetchTargetsByX(
-      camX,
-      PREFETCH_RADIUS_INNER,
-      PREFETCH_RADIUS_OUTER,
+    const candidates = index.getCandidatesInRadius(camX, camZ, BROAD_RADIUS);
+
+    camera.updateMatrix();
+    camera.updateMatrixWorld();
+
+    const projScreenMatrix = new THREE.Matrix4();
+    projScreenMatrix.multiplyMatrices(
+      camera.projectionMatrix,
+      camera.matrixWorldInverse,
     );
+    const frustum = new THREE.Frustum();
+    frustum.setFromProjectionMatrix(projScreenMatrix);
 
-    const nextVisible = new Set(visible.map((v) => v.index));
+    const nextVisible = new Set<number>();
+    const nextPrefetch = new Set<string>();
+
+    candidates.forEach(({ index: idx, modelPath }) => {
+      const { room, position } = positionedRooms[idx];
+      const center = new THREE.Vector3(position[0], position[1], position[2]);
+
+      const baseSphere = new THREE.Sphere(center, ROOM_RADIUS);
+      const marginSphere = new THREE.Sphere(
+        center,
+        ROOM_RADIUS + PREFETCH_MARGIN,
+      );
+
+      const inBase = frustum.intersectsSphere(baseSphere);
+      const inMargin = frustum.intersectsSphere(marginSphere);
+
+      if (inBase) {
+        nextVisible.add(idx);
+      } else if (inMargin) {
+        const path = room.modelPath ?? modelPath;
+        if (path) {
+          nextPrefetch.add(path);
+        }
+      }
+    });
 
     setVisibleIndices((prev) => {
       if (prev.size === nextVisible.size) {
@@ -64,7 +97,7 @@ export default function HiveRoomsScene({
       return nextVisible;
     });
 
-    setPrefetchPaths(prefetch.map((v) => v.modelPath));
+    setPrefetchPaths(Array.from(nextPrefetch));
   });
 
   useEffect(() => {

--- a/src/pages/main/engine/HiveSpatialIndex.ts
+++ b/src/pages/main/engine/HiveSpatialIndex.ts
@@ -6,9 +6,6 @@ export class HiveSpatialIndex {
     modelPath: string;
   }[];
 
-  private minX: number;
-  private maxX: number;
-
   constructor(
     positionedRooms: { room: Room; position: [number, number, number] }[],
   ) {
@@ -18,39 +15,16 @@ export class HiveSpatialIndex {
       z: position[2],
       modelPath: room.modelPath ?? '',
     }));
-    const xs = this.items.map((i) => i.x);
-    this.minX = Math.min(...xs);
-    this.maxX = Math.max(...xs);
   }
 
-  getVisibleByX(cameraX: number, halfWidth: number) {
-    const left = cameraX - halfWidth;
-    const right = cameraX + halfWidth;
+  getCandidatesInRadius(camX: number, camZ: number, radius: number) {
+    const r2 = radius * radius;
 
     return this.items.filter((item) => {
-      return item.x >= left && item.x <= right;
+      const dx = item.x - camX;
+      const dz = item.z - camZ;
+      const dist2 = dx * dx + dz * dz;
+      return dist2 <= r2;
     });
-  }
-
-  getPrefetchTargetsByX(
-    cameraX: number,
-    innerHalfWidth: number,
-    outerHalfWidth: number,
-  ) {
-    const innerLeft = cameraX - innerHalfWidth;
-    const innerRight = cameraX + innerHalfWidth;
-    const outerLeft = cameraX - outerHalfWidth;
-    const outerRight = cameraX + outerHalfWidth;
-
-    return this.items.filter((item) => {
-      const x = item.x;
-      const inOuter = x >= outerLeft && x <= outerRight;
-      const inInner = x >= innerLeft && x <= innerRight;
-      return inOuter && !inInner;
-    });
-  }
-  
-  getHorizontalBounds() {
-    return { minX: this.minX, maxX: this.maxX };
   }
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/preview-183` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
HiveRooms Scene 렌더링에 가상 스크롤 + 프러스텀 필터링 기반 프리패칭 시스템을 도입하여 성능 최적화를 진행

기존에는 X좌표만 기반으로 렌더링 여부를 판단했으나, 이번 작업으로 카메라 위치 및 시야각을 고려한 시각적 가시성 기반 렌더링 구조로 변경

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] HiveSpatialIndex를 반경 기반 필터링(`getCandidatesInRadius`) 구조로 개선
- [x] HiveRoomsScene에 프러스텀 culling + Sphere narrow filtering 추가
- [x] 반경 영역 밖 GLTF 모델 사전 로딩(Prefetch) 추가
- [x] 기존 X축 기반 필터링 제거
- [x] 성능 향상을 위한 메모리 할당 최소화 구조 설계

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#183 