### PR TITLE
🚨 Fix: fallback 적용으로 사라지는 영역 제거

### DIFF
--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -31,6 +31,8 @@ export default function HiveRoomsScene({
   const indexRef = useRef<HiveSpatialIndex | null>(null);
   const [visibleIndices, setVisibleIndices] = useState<Set<number>>(new Set());
   const [prefetchPaths, setPrefetchPaths] = useState<string[]>([]);
+  const initializedRef = useRef(false);
+  const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     if (!positionedRooms.length) return;
@@ -56,6 +58,7 @@ export default function HiveRoomsScene({
     frustum.setFromProjectionMatrix(projScreenMatrix);
 
     const nextVisible = new Set<number>();
+    const marginIndices = new Set<number>();
     const nextPrefetch = new Set<string>();
 
     items.forEach(({ index: idx, modelPath }) => {
@@ -77,6 +80,7 @@ export default function HiveRoomsScene({
       if (inBase) {
         nextVisible.add(idx);
       } else if (inMargin) {
+        marginIndices.add(idx);
         const path = room.modelPath ?? modelPath;
         if (path) {
           nextPrefetch.add(path);
@@ -84,6 +88,14 @@ export default function HiveRoomsScene({
       }
     });
 
+    if (nextVisible.size === 0 && marginIndices.size > 0) {
+      marginIndices.forEach((idx) => nextVisible.add(idx));
+    }
+
+    if (!initializedRef.current && nextVisible.size > 0) {
+      initializedRef.current = true;
+      setInitialized(true);
+    }
 
     setVisibleIndices((prev) => {
       if (prev.size === nextVisible.size) {
@@ -112,7 +124,7 @@ export default function HiveRoomsScene({
     <>
       {positionedRooms
         .filter(({ index }) => {
-          if (visibleIndices.size === 0) return true;
+          if (!initialized) return true;
           return visibleIndices.has(index);
         })
         .map(({ room, position, index }) => (


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`hotfix` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
드래그 이동 시 특정 구간에서 방 모델이 전부 사라졌다가 다시 나타나는 문제가 발견되어,  
프러스텀 기반 가상 스크롤 로직을 개선하고 **fallback margin visibility** 전략을 적용

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `frustum.intersectsSphere` 기반 가시성 판단 로직 보완
- [x] baseSphere에 걸리지 않더라도 marginSphere에 걸린 방들은 fallback visible 후보로 승격
- [x] 초기 1~2프레임 동안 전체 렌더링하도록 `initialized` 플래그 도입
- [x] 빈 화면이 나타나는 프레임 제거
- [x] 프리패칭 로직은 margin sphere 기준으로 자연스럽게 유지

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- PR에 대해 어떻게 생각하시나요?

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
[이슈 번호/정보](이슈 url)