### PR TITLE
[fix/preview-190]🚨 Fix: NDC 기반 가상 스크롤 + 프리패칭 방식 변경

### DIFF
--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -15,8 +15,8 @@ interface HiveRoomsSceneProps {
   onModelLoaded: (roomId: string) => void;
 }
 
-const ROOM_RADIUS = 2.5;
-const PREFETCH_MARGIN = 6;
+const SCREEN_INNER_MARGIN = 1.0;
+const SCREEN_OUTER_MARGIN = 1.2;
 
 export default function HiveRoomsScene({
   positionedRooms,
@@ -31,6 +31,7 @@ export default function HiveRoomsScene({
   const indexRef = useRef<HiveSpatialIndex | null>(null);
   const [visibleIndices, setVisibleIndices] = useState<Set<number>>(new Set());
   const [prefetchPaths, setPrefetchPaths] = useState<string[]>([]);
+
   const initializedRef = useRef(false);
   const [initialized, setInitialized] = useState(false);
 
@@ -45,51 +46,56 @@ export default function HiveRoomsScene({
     if (!positionedRooms.length) return;
 
     const items = index.getAll();
-
-    camera.updateMatrix();
-    camera.updateMatrixWorld();
-
-    const projScreenMatrix = new THREE.Matrix4();
-    projScreenMatrix.multiplyMatrices(
-      camera.projectionMatrix,
-      camera.matrixWorldInverse,
-    );
-    const frustum = new THREE.Frustum();
-    frustum.setFromProjectionMatrix(projScreenMatrix);
-
     const nextVisible = new Set<number>();
-    const marginIndices = new Set<number>();
     const nextPrefetch = new Set<string>();
 
-    items.forEach(({ index: idx, modelPath }) => {
+    let nearest: { idx: number; dist2: number } | null = null;
+
+    for (const item of items) {
+      const { index: idx, modelPath } = item;
       const positioned = positionedRooms[idx];
-      if (!positioned) return;
+      if (!positioned) continue;
 
       const { room, position } = positioned;
-      const center = new THREE.Vector3(position[0], position[1], position[2]);
+      const [x, y, z] = position;
 
-      const baseSphere = new THREE.Sphere(center, ROOM_RADIUS);
-      const marginSphere = new THREE.Sphere(
-        center,
-        ROOM_RADIUS + PREFETCH_MARGIN,
-      );
+      // 월드 좌표 → NDC(-1~1) 변환
+      const vec = new THREE.Vector3(x, y, z);
+      vec.project(camera); 
 
-      const inBase = frustum.intersectsSphere(baseSphere);
-      const inMargin = frustum.intersectsSphere(marginSphere);
+      const ndcX = vec.x;
+      const ndcY = vec.y;
+      const ndcZ = vec.z;
 
-      if (inBase) {
+      const dist2 = ndcX * ndcX + ndcY * ndcY;
+      if (!nearest || dist2 < nearest.dist2) {
+        nearest = { idx, dist2 };
+      }
+
+      const inView =
+        ndcZ >= -1 &&
+        ndcZ <= 1 &&
+        Math.abs(ndcX) <= SCREEN_INNER_MARGIN &&
+        Math.abs(ndcY) <= SCREEN_INNER_MARGIN;
+
+      const inPrefetch =
+        ndcZ >= -1.2 &&
+        ndcZ <= 1.2 &&
+        Math.abs(ndcX) <= SCREEN_OUTER_MARGIN &&
+        Math.abs(ndcY) <= SCREEN_OUTER_MARGIN;
+
+      if (inView) {
         nextVisible.add(idx);
-      } else if (inMargin) {
-        marginIndices.add(idx);
+      } else if (inPrefetch) {
         const path = room.modelPath ?? modelPath;
         if (path) {
           nextPrefetch.add(path);
         }
       }
-    });
+    }
 
-    if (nextVisible.size === 0 && marginIndices.size > 0) {
-      marginIndices.forEach((idx) => nextVisible.add(idx));
+    if (nextVisible.size === 0 && nearest) {
+      nextVisible.add(nearest.idx);
     }
 
     if (!initializedRef.current && nextVisible.size > 0) {

--- a/src/pages/main/engine/HiveSpatialIndex.ts
+++ b/src/pages/main/engine/HiveSpatialIndex.ts
@@ -2,6 +2,7 @@ export class HiveSpatialIndex {
   private items: {
     index: number;
     x: number;
+    y: number;
     z: number;
     modelPath: string;
   }[];
@@ -12,9 +13,12 @@ export class HiveSpatialIndex {
     this.items = positionedRooms.map(({ room, position }, index) => ({
       index,
       x: position[0],
+      y: position[1],
       z: position[2],
       modelPath: room.modelPath ?? '',
     }));
+
+    this.items.sort((a, b) => a.x - b.x);
   }
 
   getAll() {


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/preview-190` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
화면 이동 시 방 모델링이 통째로 사라지는 문제가 발견되어,  
기존 camera.x / frustum 기반 가시성 판별 방식을 제거하고  
NDC 기반 가상 스크롤 + 프리패칭 방식으로 변경

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] 기존 camera.x / frustum sphere 기반 가시성 체크 제거
- [x] 월드 좌표 → NDC 기반 `inView / inPrefetch` 판별 구현
- [x] 화면 기준 fallback visible 보장 (빈 화면 방지)
- [x] 초기 init 전 전체 렌더링 처리 (UX 부드럽게 유지)
- [x] 기존 배치 및 카메라 로직에는 영향 없음 (HexGrid 유지)
- [x] 프리패칭 로직은 경계 margin 기준으로 자연스럽게 유지

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#190 
