### PR TITLE
[fix/preview-193] 🚨 Fix: 브라우저 화면 기준의 NDC → World 변환

### DIFF
--- a/src/pages/main/components/HiveRoomsScene.tsx
+++ b/src/pages/main/components/HiveRoomsScene.tsx
@@ -15,8 +15,7 @@ interface HiveRoomsSceneProps {
   onModelLoaded: (roomId: string) => void;
 }
 
-const SCREEN_INNER_MARGIN = 1.0;
-const SCREEN_OUTER_MARGIN = 1.2;
+const PREFETCH_MARGIN_WORLD = 3;
 
 export default function HiveRoomsScene({
   positionedRooms,
@@ -32,8 +31,15 @@ export default function HiveRoomsScene({
   const [visibleIndices, setVisibleIndices] = useState<Set<number>>(new Set());
   const [prefetchPaths, setPrefetchPaths] = useState<string[]>([]);
 
-  const initializedRef = useRef(false);
-  const [initialized, setInitialized] = useState(false);
+  const screenToWorld = (x: number, y: number) => {
+    const vec = new THREE.Vector3(
+      (x / window.innerWidth) * 2 - 1,
+      -(y / window.innerHeight) * 2 + 1,
+      0.5,
+    );
+    vec.unproject(camera);
+    return vec;
+  };
 
   useEffect(() => {
     if (!positionedRooms.length) return;
@@ -45,63 +51,46 @@ export default function HiveRoomsScene({
     if (!index) return;
     if (!positionedRooms.length) return;
 
+    const TL = screenToWorld(0, 0);
+    const TR = screenToWorld(window.innerWidth, 0);
+    const BL = screenToWorld(0, window.innerHeight);
+    const BR = screenToWorld(window.innerWidth, window.innerHeight);
+
+    const minX = Math.min(TL.x, TR.x, BL.x, BR.x);
+    const maxX = Math.max(TL.x, TR.x, BL.x, BR.x);
+    const minZ = Math.min(TL.z, TR.z, BL.z, BR.z);
+    const maxZ = Math.max(TL.z, TR.z, BL.z, BR.z);
+
     const items = index.getAll();
+
     const nextVisible = new Set<number>();
     const nextPrefetch = new Set<string>();
 
-    let nearest: { idx: number; dist2: number } | null = null;
-
-    for (const item of items) {
-      const { index: idx, modelPath } = item;
+    items.forEach(({ index: idx, modelPath }) => {
       const positioned = positionedRooms[idx];
-      if (!positioned) continue;
+      if (!positioned) return;
 
       const { room, position } = positioned;
-      const [x, y, z] = position;
-
-      // 월드 좌표 → NDC(-1~1) 변환
-      const vec = new THREE.Vector3(x, y, z);
-      vec.project(camera); 
-
-      const ndcX = vec.x;
-      const ndcY = vec.y;
-      const ndcZ = vec.z;
-
-      const dist2 = ndcX * ndcX + ndcY * ndcY;
-      if (!nearest || dist2 < nearest.dist2) {
-        nearest = { idx, dist2 };
-      }
+      const x = position[0];
+      const z = position[2];
 
       const inView =
-        ndcZ >= -1 &&
-        ndcZ <= 1 &&
-        Math.abs(ndcX) <= SCREEN_INNER_MARGIN &&
-        Math.abs(ndcY) <= SCREEN_INNER_MARGIN;
+        x >= minX && x <= maxX &&
+        z >= minZ && z <= maxZ;
 
-      const inPrefetch =
-        ndcZ >= -1.2 &&
-        ndcZ <= 1.2 &&
-        Math.abs(ndcX) <= SCREEN_OUTER_MARGIN &&
-        Math.abs(ndcY) <= SCREEN_OUTER_MARGIN;
+      const inMargin =
+        x >= minX - PREFETCH_MARGIN_WORLD &&
+        x <= maxX + PREFETCH_MARGIN_WORLD &&
+        z >= minZ - PREFETCH_MARGIN_WORLD &&
+        z <= maxZ + PREFETCH_MARGIN_WORLD;
 
       if (inView) {
         nextVisible.add(idx);
-      } else if (inPrefetch) {
+      } else if (inMargin) {
         const path = room.modelPath ?? modelPath;
-        if (path) {
-          nextPrefetch.add(path);
-        }
+        if (path) nextPrefetch.add(path);
       }
-    }
-
-    if (nextVisible.size === 0 && nearest) {
-      nextVisible.add(nearest.idx);
-    }
-
-    if (!initializedRef.current && nextVisible.size > 0) {
-      initializedRef.current = true;
-      setInitialized(true);
-    }
+    });
 
     setVisibleIndices((prev) => {
       if (prev.size === nextVisible.size) {
@@ -129,10 +118,7 @@ export default function HiveRoomsScene({
   return (
     <>
       {positionedRooms
-        .filter(({ index }) => {
-          if (!initialized) return true;
-          return visibleIndices.has(index);
-        })
+        .filter(({ index }) => visibleIndices.has(index))
         .map(({ room, position, index }) => (
           <group
             key={room.roomId}

--- a/src/pages/main/engine/HiveSpatialIndex.ts
+++ b/src/pages/main/engine/HiveSpatialIndex.ts
@@ -2,7 +2,6 @@ export class HiveSpatialIndex {
   private items: {
     index: number;
     x: number;
-    y: number;
     z: number;
     modelPath: string;
   }[];
@@ -13,12 +12,9 @@ export class HiveSpatialIndex {
     this.items = positionedRooms.map(({ room, position }, index) => ({
       index,
       x: position[0],
-      y: position[1],
       z: position[2],
       modelPath: room.modelPath ?? '',
     }));
-
-    this.items.sort((a, b) => a.x - b.x);
   }
 
   getAll() {


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`fix/preview-193` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
메인 Hive 프리뷰에서 방 모델링 개수가 늘어났을 때,
- 드래그 이동 중 특정 구간에서 방들이 통째로 사라지거나
- 화면에 아무것도 렌더링되지 않는 빈 화면이 노출되는 문제가 계속 발생

이를 해결하기 위해, **브라우저 화면 기준의 NDC → World 변환을 사용**
- 화면에 실제로 보이는 방만 렌더링하는 3D 가상 스크롤
- 화면 경계 근처의 방들은 프리패칭만 수행하는 프리패칭 레이어

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `HiveSpatialIndex`를 단순 Room 위치/모델 경로 인덱스로 정리
- [x] `HiveRoomsScene`에서 `screenToWorld`를 통해 화면 4 모서리를 World 좌표로 계산
- [x] 화면 4점(TL, TR, BL, BR) 기반 XZ 평면 AABB를 만들어 가시성 판별
- [x] AABB 내부에 있는 방만 렌더링하는 3D 가상 스크롤 로직 적용
- [x] AABB ± margin 범위에 있는 방 모델만 `useGLTF.preload`로 프리패칭
- [x] 기존 Hexagon 배치 로직 및 OrbitControls 설정은 그대로 유지하여 배치/카메라 UX 영향 최소화


<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- PR에 대해 어떻게 생각하시나요?

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#193